### PR TITLE
fix(desktop): use a single main category in Linux menu entry

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -279,7 +279,7 @@ jobs:
             'Icon=infraeye' \
             'Terminal=false' \
             'Type=Application' \
-            'Categories=Utility;Development;' \
+            'Categories=Development;Monitor;' \
             > "$PKGROOT/usr/share/applications/infraeye.desktop"
 
           printf '%s\n' \
@@ -325,7 +325,7 @@ jobs:
             'Icon=infraeye' \
             'Terminal=false' \
             'Type=Application' \
-            'Categories=Utility;Development;' \
+            'Categories=Development;Monitor;' \
             > "$PKGDIR/infraeye.desktop"
 
           printf '%s\n' \


### PR DESCRIPTION
Closes #19.

Changes the generated Linux `.desktop` entry in both packaging steps (deb and Arch) from `Categories=Utility;Development;` to `Categories=Development;Monitor;`, so the freedesktop menu spec has a single main category and the app no longer risks appearing twice in the menu. `Monitor` is the registered additional category for system/network monitoring tools.