### PR TITLE
ci: disable automatic SonarQube runs until secrets exist

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -26,11 +26,9 @@
 
 name: SonarQube analysis
 
+# Disabled for automatic runs until SONAR_TOKEN (and SONAR_HOST_URL for
+# self-hosted) are configured as repository secrets. Keep manual runs available.
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes #13.

Stops the SonarQube workflow from running on every push/PR until `SONAR_TOKEN` and `SONAR_HOST_URL` are configured as repository secrets. The workflow remains available as a manual `workflow_dispatch` run once the secrets are added.