### PR TITLE
fix: verify MCP server with JSON-RPC initialize

### DIFF
--- a/backend/internal/handlers/mcp.go
+++ b/backend/internal/handlers/mcp.go
@@ -28,6 +28,10 @@ var mcpClient = &http.Client{Timeout: 60 * time.Second}
 // A 30s timeout on the shared client was killing the stream before tool responses arrived.
 var mcpSSEClient = &http.Client{Timeout: 0}
 
+// mcpStatusClient is intentionally short-lived: /api/mcp/status must not hang
+// while a wrong process is bound to the configured port.
+var mcpStatusClient = &http.Client{Timeout: 5 * time.Second}
+
 
 // ── MCP JSON-RPC types ─────────────────────────────────────────────────────
 
@@ -166,28 +170,74 @@ func MCPServerStatus(c *gin.Context) {
 		log.Printf("⚠️ MCP: Kubeconfig sync failed: %v", err)
 	}
 
-	resp, err := mcpClient.Get(config.C.MCPServerURL + "/healthz")
+	available, statusCode, details := checkMCPServer(config.C.MCPServerURL)
+	body := gin.H{
+		"available":   available,
+		"url":         config.C.MCPServerURL,
+		"status_code": statusCode,
+	}
+	if details != "" {
+		body["details"] = details
+	}
+	c.JSON(http.StatusOK, body)
+}
+
+func checkMCPServer(baseURL string) (bool, int, string) {
+	payload := mcpRequest{
+		JSONRPC: "2.0",
+		ID:      intPtr(1),
+		Method:  "initialize",
+		Params: map[string]interface{}{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]interface{}{},
+			"clientInfo": map[string]string{
+				"name":    "infra-eye-status",
+				"version": "1.0.0",
+			},
+		},
+	}
+	body, err := json.Marshal(payload)
 	if err != nil {
-		// Try fallback to root if /health 404s or fails
-		resp, err = mcpClient.Get(config.C.MCPServerURL + "/sse")
+		return false, 0, fmt.Sprintf("marshal initialize request: %v", err)
 	}
 
+	target := strings.TrimRight(baseURL, "/") + "/mcp"
+	req, err := http.NewRequest(http.MethodPost, target, bytes.NewBuffer(body))
 	if err != nil {
-		c.JSON(http.StatusOK, gin.H{
-			"available": false,
-			"url":       config.C.MCPServerURL,
-			"error":     err.Error(),
-			"hint":      "Check if mcp-server container is running and port 8090 is open",
-		})
-		return
+		return false, 0, fmt.Sprintf("create MCP status request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := mcpStatusClient.Do(req)
+	if err != nil {
+		return false, 0, fmt.Sprintf("MCP server unreachable: %v", err)
 	}
 	defer resp.Body.Close()
 
-	c.JSON(http.StatusOK, gin.H{
-		"available":   resp.StatusCode == 200 || resp.StatusCode == 404, // 404 means server is up but endpoint missing
-		"url":         config.C.MCPServerURL,
-		"status_code": resp.StatusCode,
-	})
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, resp.StatusCode, fmt.Sprintf("read MCP status response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, resp.StatusCode, fmt.Sprintf("MCP server returned HTTP %d", resp.StatusCode)
+	}
+
+	var decoded mcpResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return false, resp.StatusCode, "MCP endpoint returned a non-JSON-RPC response"
+	}
+	if decoded.JSONRPC != "2.0" || decoded.ID != 1 {
+		return false, resp.StatusCode, "MCP endpoint returned an unexpected JSON-RPC response"
+	}
+	if decoded.Error != nil {
+		return false, resp.StatusCode, fmt.Sprintf("MCP initialize failed: %s", decoded.Error.Message)
+	}
+	if len(decoded.Result) == 0 {
+		return false, resp.StatusCode, "MCP initialize returned no result"
+	}
+
+	return true, resp.StatusCode, ""
 }
 
 var (

--- a/backend/internal/handlers/mcp_test.go
+++ b/backend/internal/handlers/mcp_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckMCPServerAcceptsJSONRPCMCPResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"kubernetes-mcp-server","version":"1.0.0"}}}`))
+	}))
+	defer server.Close()
+
+	available, statusCode, details := checkMCPServer(server.URL)
+	if !available {
+		t.Fatalf("expected MCP server to be available, got details=%q", details)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", statusCode)
+	}
+}
+
+func TestCheckMCPServerRejectsUnrelatedHTTPService(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>not kubernetes-mcp-server</html>"))
+	}))
+	defer server.Close()
+
+	available, _, _ := checkMCPServer(server.URL)
+	if available {
+		t.Fatal("expected an unrelated HTTP service to be reported unavailable")
+	}
+}
+
+func TestCheckMCPServerRejectsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	available, statusCode, _ := checkMCPServer(server.URL)
+	if available {
+		t.Fatal("expected a 500 response to be reported unavailable")
+	}
+	if statusCode != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", statusCode)
+	}
+}
+
+func TestCheckMCPServerReportsUnreachable(t *testing.T) {
+	available, _, details := checkMCPServer("http://127.0.0.1:1")
+	if available {
+		t.Fatal("expected unreachable endpoint to be reported unavailable")
+	}
+	if details == "" {
+		t.Fatal("expected an unreachable endpoint to include details")
+	}
+}


### PR DESCRIPTION
Closes #11.

`/api/mcp/status` now sends a JSON-RPC `initialize` request to `/mcp` and only reports `available: true` when the response has the expected JSON-RPC shape and a result. A different process bound to port 8090 that returns HTML or any other non-MCP payload is reported unavailable.

Verified with unit tests covering a valid JSON-RPC response, an unrelated HTTP service, a 500 response, and an unreachable endpoint.