### PR TITLE
chore: bump version to 1.6.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Security fix release: patched Go/npm dependencies (golang.org/x/crypto, axios, react-router, js-yaml, and others) and hardened several CodeQL findings (git argument injection, insecure cookies, SSRF host allowlisting, XML injection in AlertRules import/export). Bumps frontend/package.json to 1.6.2 to match the desktop-v1.6.2 tag this PR is preparing.