### PR TITLE
chore: bump version to 1.6.3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Ships the desktop update-button fix (#108) — `window.confirm()` was silently no-oping in Wails' embedded webview, replaced with an in-app Modal. Bumps frontend/package.json to 1.6.3 to match the desktop-v1.6.3 tag this PR is preparing.