### PR TITLE
feat: add local LLM provider to Netra AI

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	DeepSeekKey           string
 	OpenRouterKey         string
 	MistralKey            string
+	LocalLLMURL           string
+	LocalLLMModel         string
 	ResourceGatewayURL    string
 	ResourceGatewayToken  string
 	MetricsInterval       int
@@ -59,6 +61,8 @@ func Load() {
 		DeepSeekKey:     getEnv("DEEPSEEK_API_KEY", ""),
 		OpenRouterKey:   getEnv("OPENROUTER_API_KEY", ""),
 		MistralKey:      getEnv("MISTRAL_API_KEY", ""),
+		LocalLLMURL:     getEnv("LOCAL_LLM_URL", ""),
+		LocalLLMModel:   getEnv("LOCAL_LLM_MODEL", "llama3.2"),
 		MetricsInterval: getEnvInt("METRICS_INTERVAL", 30),
 		LogMaxLines:            getEnvInt("LOG_MAX_LINES", 500),
 		GoogleChatWebhookURL:   getEnv("GOOGLE_CHAT_WEBHOOK_URL", ""),

--- a/backend/internal/handlers/ai.go
+++ b/backend/internal/handlers/ai.go
@@ -613,6 +613,16 @@ func askAI(systemContext, question, imageBase64, imageMime, provider string, use
 		if user.ClaudeKey != "" { return askClaude(systemContext, question, user.ClaudeKey) }
 	}
 
+	// Local LLM (self-hosted, OpenAI-compatible: Ollama, LM Studio, llama.cpp server, vLLM)
+	if provider == "local" || (provider == "" && (user.LocalLLMURL != "" || config.C.LocalLLMURL != "")) {
+		url := config.C.LocalLLMURL
+		if user.LocalLLMURL != "" { url = user.LocalLLMURL }
+		model := config.C.LocalLLMModel
+		if user.LocalLLMModel != "" { model = user.LocalLLMModel }
+		if url != "" { return askLocalLLM(systemContext, question, url, model) }
+		if provider == "local" { return "No local LLM endpoint configured. Set LOCAL_LLM_URL (server-wide) or add your local endpoint in Settings → AI." }
+	}
+
 	// OpenRouter (Default fallback)
 	if provider == "openrouter" || provider == "" {
 		key := config.C.OpenRouterKey
@@ -763,6 +773,55 @@ func askDeepSeek(systemContext, question, apiKey string) string {
 
 	if len(aiResp.Choices) == 0 {
 		return "No response from DeepSeek AI."
+	}
+
+	return aiResp.Choices[0].Message.Content.(string)
+}
+
+// askLocalLLM talks to a self-hosted, OpenAI-compatible chat endpoint (Ollama,
+// LM Studio, llama.cpp server, vLLM, text-generation-webui). No API key is
+// required since these run on trusted infrastructure the operator controls.
+func askLocalLLM(systemContext, question, baseURL, model string) string {
+	endpoint := strings.TrimRight(baseURL, "/")
+	if !strings.Contains(endpoint, "/chat/completions") {
+		endpoint += "/v1/chat/completions"
+	}
+
+	reqBody := openAIRequest{
+		Model: model,
+		Messages: []openAIMessage{
+			{Role: "system", Content: systemContext},
+			{Role: "user", Content: question},
+		},
+	}
+
+	jsonData, _ := json.Marshal(reqBody)
+	httpReq, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Sprintf("Request creation failed: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Local inference (especially on CPU) can be slow, so allow a generous timeout.
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return fmt.Sprintf("Local LLM request failed: %v (is the server running at %s?)", err, endpoint)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var aiResp openAIResponse
+	if err := json.Unmarshal(body, &aiResp); err != nil {
+		return fmt.Sprintf("Local LLM parse error: %v | raw: %s", err, string(body))
+	}
+
+	if aiResp.Error != nil {
+		return fmt.Sprintf("Local LLM error: %s", aiResp.Error.Message)
+	}
+
+	if len(aiResp.Choices) == 0 {
+		return "No response from local LLM."
 	}
 
 	return aiResp.Choices[0].Message.Content.(string)

--- a/backend/internal/handlers/users.go
+++ b/backend/internal/handlers/users.go
@@ -148,6 +148,8 @@ func UpdateProfile(c *gin.Context) {
 		ClaudeKey     string `json:"claude_key"`
 		GeminiKey     string `json:"gemini_key"`
 		MistralKey    string `json:"mistral_key"`
+		LocalLLMURL   string `json:"local_llm_url"`
+		LocalLLMModel string `json:"local_llm_model"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -171,6 +173,12 @@ func UpdateProfile(c *gin.Context) {
 	if body.MistralKey != "" {
 		user.MistralKey = body.MistralKey
 	}
+	if body.LocalLLMURL != "" {
+		user.LocalLLMURL = body.LocalLLMURL
+	}
+	if body.LocalLLMModel != "" {
+		user.LocalLLMModel = body.LocalLLMModel
+	}
 	if body.Password != "" {
 		if len(body.Password) < 6 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "password must be at least 6 characters"})
@@ -191,6 +199,8 @@ func UpdateProfile(c *gin.Context) {
 		"claude_key":      user.ClaudeKey,
 		"gemini_key":      user.GeminiKey,
 		"mistral_key":     user.MistralKey,
+		"local_llm_url":   user.LocalLLMURL,
+		"local_llm_model": user.LocalLLMModel,
 	})
 }
 

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -24,6 +24,11 @@ type User struct {
 	ClaudeKey     string `json:"claude_key"`
 	GeminiKey     string `json:"gemini_key"`
 	MistralKey    string `json:"mistral_key"`
+	// LocalLLMURL points at a self-hosted, OpenAI-compatible chat endpoint
+	// (Ollama, LM Studio, llama.cpp server, vLLM). Overrides the server-wide
+	// LOCAL_LLM_URL/LOCAL_LLM_MODEL env defaults when set.
+	LocalLLMURL   string `json:"local_llm_url"`
+	LocalLLMModel string `json:"local_llm_model"`
 }
 
 type Server struct {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.3",
+  "version": "1.6.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/AIAssistant.tsx
+++ b/frontend/src/pages/AIAssistant.tsx
@@ -116,7 +116,7 @@ export function AIAssistant() {
   const [question, setQuestion] = useState('')
   const [messages, setMessages] = useState<Message[]>([])
   const [loading, setLoading] = useState(false)
-  const [provider, setProvider] = useState<'openrouter' | 'deepseek' | 'google' | 'mistral' | 'claude'>('mistral')
+  const [provider, setProvider] = useState<'openrouter' | 'deepseek' | 'google' | 'mistral' | 'claude' | 'local'>('mistral')
   const [mcpAvailable, setMcpAvailable] = useState(false)
   const [inputFocused, setInputFocused] = useState(false)
 
@@ -420,6 +420,7 @@ export function AIAssistant() {
                 <option value="google">Gemini</option>
                 <option value="deepseek">DeepSeek</option>
                 <option value="openrouter">OpenRouter</option>
+                <option value="local">Local LLM</option>
               </select>
               <ChevronDown size={13} color="var(--text-muted)" style={{ position: 'absolute', right: 8, pointerEvents: 'none' }} />
             </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -33,6 +33,8 @@ export function Settings() {
   const [claudeKey, setClaudeKey] = useState((currentUser as any)?.claude_key || '')
   const [geminiKey, setGeminiKey] = useState((currentUser as any)?.gemini_key || '')
   const [mistralKey, setMistralKey] = useState((currentUser as any)?.mistral_key || '')
+  const [localLLMURL, setLocalLLMURL] = useState((currentUser as any)?.local_llm_url || '')
+  const [localLLMModel, setLocalLLMModel] = useState((currentUser as any)?.local_llm_model || '')
 
   // Notification webhook state (admin only)
   const [gchatUrl, setGchatUrl] = useState('')
@@ -125,6 +127,8 @@ export function Settings() {
       payload.claude_key = claudeKey
       payload.gemini_key = geminiKey
       payload.mistral_key = mistralKey
+      payload.local_llm_url = localLLMURL
+      payload.local_llm_model = localLLMModel
 
       const res = await api.put('/api/auth/me', payload)
       useAuthStore.getState().setAuth(useAuthStore.getState().token!, res.data)
@@ -351,6 +355,21 @@ export function Settings() {
                     <div className="input-group">
                       <label className="input-label">Mistral API Key</label>
                       <input className="input" type="password" value={mistralKey} onChange={e => setMistralKey(e.target.value)} placeholder="sk-..." />
+                    </div>
+                  </div>
+
+                  <div style={{ paddingTop: 8, borderTop: '1px solid var(--border)' }}>
+                    <h3 style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)', margin: '20px 0 4px' }}>Local LLM</h3>
+                    <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 16 }}>Point Netra at a self-hosted, OpenAI-compatible endpoint — Ollama, LM Studio, llama.cpp server, or vLLM. No API key needed; runs entirely on infrastructure you control.</p>
+                    <div className="grid-2-col" style={{ gap: 20 }}>
+                      <div className="input-group">
+                        <label className="input-label">Endpoint URL</label>
+                        <input className="input" type="text" value={localLLMURL} onChange={e => setLocalLLMURL(e.target.value)} placeholder="http://localhost:11434" />
+                      </div>
+                      <div className="input-group">
+                        <label className="input-label">Model Name</label>
+                        <input className="input" type="text" value={localLLMModel} onChange={e => setLocalLLMModel(e.target.value)} placeholder="llama3.2" />
+                      </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Adds a "Local LLM" option to Netra AI's provider selection, alongside Claude, Gemini, DeepSeek, OpenRouter, and Mistral — lets users point the assistant at a self-hosted, OpenAI-compatible chat endpoint (Ollama, LM Studio, llama.cpp server, vLLM) instead of a cloud API key.
- Backend: `LOCAL_LLM_URL` / `LOCAL_LLM_MODEL` server-wide config (`.env`), with an optional per-user override stored on the `User` model and editable from Settings. New `askLocalLLM()` posts to `{url}/v1/chat/completions`, no API key required.
- Frontend: "Local LLM" entry in the AI Assistant provider dropdown (`AIAssistant.tsx`), and a new Endpoint URL / Model Name section in Settings → AI (`Settings.tsx`).
- Bumps version to 1.6.4.

## Test plan
- [x] `go build` + `go vet` pass clean
- [x] `tsc -b` passes clean (frontend type-check)
- [x] Verified end-to-end against a local Ollama instance: started Postgres/Redis/backend/frontend locally, logged in, called `POST /api/ai/chat` with `"provider":"local"`, got a real generated answer back and confirmed the chat thread was persisted correctly
- [ ] Manual click-through in the browser (dropdown selection + Settings save) — not yet done in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)