### PR TITLE
fix(ci): free macOS runner disk space before desktop build

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -47,6 +47,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # macos-latest runners ship with ~14GB free after OS/toolchain overhead,
+      # most of which is preinstalled Xcode platforms/simulators and an Android
+      # SDK this build never touches. hdiutil create needs scratch space on the
+      # order of the .app bundle size to stage the compressed DMG, and as the
+      # frontend has grown that pushed a build over the edge ("No space left on
+      # device" from hdiutil, confirmed reproducible across reruns on the same
+      # commit). Clearing these frees 10GB+ before the build even starts.
+      # Leaves Xcode itself alone — codesign/notarytool need the active
+      # toolchain, and pruning "other" Xcode versions risks removing the one
+      # xcode-select actually points at.
+      - name: Free up disk space (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          df -h /
+          sudo rm -rf /Users/runner/Library/Android
+          sudo rm -rf ~/Library/Developer/CoreSimulator
+          sudo rm -rf ~/Library/Developer/Xcode/DerivedData
+          df -h /
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary
- The `desktop-v1.6.4` release build's macOS job fails reproducibly at the `hdiutil create` DMG-packaging step with "No space left on device" (confirmed on two separate reruns of the same commit).
- Every prior desktop release (1.4.0 through 1.6.3) succeeded, so this is a new regression, not a flaky runner — likely the growing frontend bundle tipping `macos-latest`'s ~14GB free disk over the edge, since `hdiutil create` needs scratch space roughly proportional to the `.app` bundle size.
- Adds a "Free up disk space (macOS)" step that clears the Android SDK, CoreSimulator caches, and Xcode DerivedData before the build starts — none of which the Wails build touches. Xcode itself is left alone since codesign/notarytool need the active toolchain.

## Test plan
- [ ] Merge and re-point the `desktop-v1.6.4` tag at the new main commit to retrigger the release workflow
- [ ] Confirm the macOS job's `hdiutil create` step succeeds and the `.dmg` is produced
- [ ] Confirm the `release` job publishes all platform assets to the GitHub Release