### PR TITLE
feat: add Agent — human-approved multi-turn DevOps orchestration

### DIFF
--- a/backend/internal/agent/claude.go
+++ b/backend/internal/agent/claude.go
@@ -1,0 +1,121 @@
+// Package agent provides a minimal Claude Messages API client that supports
+// native multi-turn tool calling (tools / tool_use / tool_result), used by
+// the Agent DevOps-orchestration handlers. It intentionally does not reuse
+// ai.go's askClaude helper, whose single-shot request/response structs use
+// a plain string message Content and cannot represent tool_use/tool_result
+// content blocks.
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ClaudeModel is the model used for all Agent tool-calling turns.
+const ClaudeModel = "claude-sonnet-5"
+
+const anthropicMessagesURL = "https://api.anthropic.com/v1/messages"
+
+// ContentBlock is one block of a Claude message. Depending on Type, only the
+// relevant fields are populated:
+//   - "text": Text
+//   - "tool_use": ID, Name, Input
+//   - "tool_result": ToolUseID, Content, IsError
+type ContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   string          `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+}
+
+// Message is one turn of the conversation, sent to or received from Claude.
+type Message struct {
+	Role    string         `json:"role"`
+	Content []ContentBlock `json:"content"`
+}
+
+// ToolDefinition describes one callable tool, in Claude's tools schema.
+type ToolDefinition struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// TurnResult is the parsed outcome of a single CallClaude turn.
+type TurnResult struct {
+	StopReason string
+	Content    []ContentBlock
+}
+
+type anthropicRequest struct {
+	Model     string           `json:"model"`
+	MaxTokens int              `json:"max_tokens"`
+	System    string           `json:"system,omitempty"`
+	Messages  []Message        `json:"messages"`
+	Tools     []ToolDefinition `json:"tools,omitempty"`
+}
+
+type anthropicResponse struct {
+	Content    []ContentBlock `json:"content"`
+	StopReason string         `json:"stop_reason"`
+	Error      *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// CallClaude sends one turn of the conversation to Claude, with the given
+// system prompt and available tools, and returns the assistant's response
+// blocks (which may include one or more tool_use blocks).
+func CallClaude(apiKey, systemPrompt string, messages []Message, tools []ToolDefinition) (*TurnResult, error) {
+	reqBody := anthropicRequest{
+		Model:     ClaudeModel,
+		MaxTokens: 4096,
+		System:    systemPrompt,
+		Messages:  messages,
+		Tools:     tools,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequest("POST", anthropicMessagesURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("x-api-key", apiKey)
+	httpReq.Header.Set("anthropic-version", "2023-06-01")
+	httpReq.Header.Set("content-type", "application/json")
+
+	client := &http.Client{Timeout: 90 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var aiResp anthropicResponse
+	if err := json.Unmarshal(body, &aiResp); err != nil {
+		return nil, fmt.Errorf("parse response: %w | raw: %s", err, string(body))
+	}
+
+	if aiResp.Error != nil {
+		return nil, fmt.Errorf("claude API error: %s", aiResp.Error.Message)
+	}
+
+	return &TurnResult{StopReason: aiResp.StopReason, Content: aiResp.Content}, nil
+}

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -55,6 +55,8 @@ func Connect() {
 		&models.ChatThread{},
 		&models.AppSetting{},
 		&models.SecurityScan{},
+		&models.AgentRun{},
+		&models.AgentStep{},
 	); err != nil {
 		log.Fatalf("Auto-migrate failed: %v", err)
 	}

--- a/backend/internal/handlers/agent.go
+++ b/backend/internal/handlers/agent.go
@@ -1,0 +1,544 @@
+// Agent orchestrates multi-turn, human-approved DevOps automation: given a
+// goal and a target server, it drives a Claude tool-calling loop that
+// proposes one SSH or Kubernetes/MCP action per turn, executes it only after
+// explicit approval, feeds the real result back, and repeats until Claude
+// produces a final answer. See docs/DESIGN_PRINCIPLES.md for why results and
+// errors are passed through to the model/user verbatim rather than abstracted.
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/infra-eye/backend/internal/agent"
+	"github.com/infra-eye/backend/internal/db"
+	"github.com/infra-eye/backend/internal/models"
+	sshclient "github.com/infra-eye/backend/internal/ssh"
+	"github.com/infra-eye/backend/internal/ws"
+)
+
+const (
+	sshToolName   = "run_ssh_command"
+	maxAgentTurns = 25
+)
+
+func agentRoom(runID uint) string {
+	return fmt.Sprintf("agent-run-%d", runID)
+}
+
+// ── Tool definitions ────────────────────────────────────────────────────────
+
+func sshToolDefinition() agent.ToolDefinition {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"server_id": {"type": "integer", "description": "Target server id; must equal the server this run is scoped to"},
+			"command": {"type": "string", "description": "Shell command to execute over SSH on the target server"}
+		},
+		"required": ["server_id", "command"]
+	}`)
+	return agent.ToolDefinition{
+		Name:        sshToolName,
+		Description: "Run a shell command over SSH on the target Linux server. Requires human approval before execution.",
+		InputSchema: schema,
+	}
+}
+
+func fetchMCPToolDefinitions() ([]agent.ToolDefinition, error) {
+	result, err := callMCPMethod("tools/list", nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	var parsed struct {
+		Tools []struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			InputSchema json.RawMessage `json:"inputSchema"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		return nil, err
+	}
+	defs := make([]agent.ToolDefinition, 0, len(parsed.Tools))
+	for _, t := range parsed.Tools {
+		defs = append(defs, agent.ToolDefinition{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: t.InputSchema,
+		})
+	}
+	return defs, nil
+}
+
+func agentPreamble(run *models.AgentRun, server models.Server) string {
+	return fmt.Sprintf(`You are InfraEye's Agent, operating in a human-approved DevOps automation loop against server %q (id %d).
+
+Goal: %s
+
+Rules:
+- Propose at most ONE tool call per turn. Every tool call requires explicit human approval before it executes — you will see the real result (or a rejection notice) before your next turn.
+- Use %s for shell commands over SSH, and the provided Kubernetes/MCP tools for cluster operations. Only target server_id %d.
+- When the goal is fully achieved, or you need to stop, respond with plain text summarizing the outcome and do not call any tool — this ends the run.
+- If a tool call is rejected, do not repeat it verbatim; propose an alternative approach or ask a clarifying question as your final answer.`,
+		server.Name, server.ID, run.Goal, sshToolName, run.ServerID)
+}
+
+// ── Conversation reconstruction ─────────────────────────────────────────────
+
+func buildMessageHistory(run *models.AgentRun, steps []models.AgentStep) []agent.Message {
+	messages := []agent.Message{
+		{Role: "user", Content: []agent.ContentBlock{{Type: "text", Text: run.Goal}}},
+	}
+
+	for _, step := range steps {
+		if step.Kind == "final_answer" || step.Status == "pending_approval" {
+			continue
+		}
+
+		assistantBlocks := []agent.ContentBlock{}
+		if step.Reasoning != "" {
+			assistantBlocks = append(assistantBlocks, agent.ContentBlock{Type: "text", Text: step.Reasoning})
+		}
+		assistantBlocks = append(assistantBlocks, agent.ContentBlock{
+			Type:  "tool_use",
+			ID:    step.ToolUseID,
+			Name:  step.ToolName,
+			Input: json.RawMessage(step.ToolArgs),
+		})
+		messages = append(messages, agent.Message{Role: "assistant", Content: assistantBlocks})
+
+		resultText := step.Output
+		isError := false
+		switch step.Status {
+		case "rejected":
+			resultText = "User rejected this action and it was not executed. Propose an alternative or ask a clarifying question."
+			isError = true
+		case "failed":
+			resultText = step.ErrorText
+			isError = true
+		}
+		messages = append(messages, agent.Message{Role: "user", Content: []agent.ContentBlock{
+			{Type: "tool_result", ToolUseID: step.ToolUseID, Content: resultText, IsError: isError},
+		}})
+	}
+
+	return messages
+}
+
+// ── Turn driver ──────────────────────────────────────────────────────────────
+
+func failAgentRun(run *models.AgentRun, errText string) {
+	now := time.Now()
+	run.Status = "failed"
+	run.ErrorText = errText
+	run.FinishedAt = &now
+	db.DB.Save(run)
+	ws.GlobalHub.Broadcast(agentRoom(run.ID), "run_failed", gin.H{"run_id": run.ID, "status": run.Status, "error": run.ErrorText})
+}
+
+// doAgentTurn executes exactly one turn of the agent loop: it calls Claude
+// with the reconstructed conversation and either creates a pending_approval
+// step (waiting for a human decision), a final_answer step (run completed),
+// or fails the run. It recurses once, synchronously, when Claude names a
+// tool that isn't offered — no human decision is needed to correct that.
+func doAgentTurn(run *models.AgentRun) {
+	var steps []models.AgentStep
+	db.DB.Where("agent_run_id = ?", run.ID).Order("step_number ASC").Find(&steps)
+
+	if len(steps) >= maxAgentTurns {
+		failAgentRun(run, fmt.Sprintf("Reached the maximum of %d turns without completing the goal.", maxAgentTurns))
+		return
+	}
+
+	var server models.Server
+	if err := db.DB.First(&server, run.ServerID).Error; err != nil {
+		failAgentRun(run, "target server not found")
+		return
+	}
+
+	var user models.User
+	if err := db.DB.First(&user, run.UserID).Error; err != nil || user.ClaudeKey == "" {
+		failAgentRun(run, "Claude API key not configured for this user")
+		return
+	}
+
+	systemPrompt := buildContext(run.ServerID) + "\n\n" + agentPreamble(run, server)
+
+	tools := []agent.ToolDefinition{sshToolDefinition()}
+	if mcpTools, err := fetchMCPToolDefinitions(); err == nil {
+		tools = append(tools, mcpTools...)
+	}
+
+	messages := buildMessageHistory(run, steps)
+
+	result, err := agent.CallClaude(user.ClaudeKey, systemPrompt, messages, tools)
+	if err != nil {
+		failAgentRun(run, err.Error())
+		return
+	}
+
+	var reasoning string
+	var toolUse *agent.ContentBlock
+	for i := range result.Content {
+		block := result.Content[i]
+		if block.Type == "text" {
+			if reasoning != "" {
+				reasoning += "\n"
+			}
+			reasoning += block.Text
+		} else if block.Type == "tool_use" && toolUse == nil {
+			toolUse = &result.Content[i]
+		}
+	}
+
+	nextStepNumber := len(steps) + 1
+
+	if toolUse == nil {
+		now := time.Now()
+		step := models.AgentStep{
+			AgentRunID: run.ID,
+			StepNumber: nextStepNumber,
+			Kind:       "final_answer",
+			Reasoning:  reasoning,
+			Status:     "executed",
+			ExecutedAt: &now,
+		}
+		db.DB.Create(&step)
+		run.Status = "completed"
+		run.FinishedAt = &now
+		db.DB.Save(run)
+		ws.GlobalHub.Broadcast(agentRoom(run.ID), "run_completed", gin.H{"run_id": run.ID, "step": step})
+		return
+	}
+
+	knownTool := toolUse.Name == sshToolName
+	if !knownTool {
+		for _, t := range tools {
+			if t.Name == toolUse.Name {
+				knownTool = true
+				break
+			}
+		}
+	}
+
+	kind := "mcp_tool"
+	if toolUse.Name == sshToolName {
+		kind = "ssh_command"
+	}
+
+	if !knownTool {
+		now := time.Now()
+		step := models.AgentStep{
+			AgentRunID: run.ID,
+			StepNumber: nextStepNumber,
+			Kind:       "unknown_tool",
+			ToolName:   toolUse.Name,
+			ToolArgs:   string(toolUse.Input),
+			ToolUseID:  toolUse.ID,
+			Reasoning:  reasoning,
+			Status:     "failed",
+			ErrorText:  fmt.Sprintf("Unknown tool %q was proposed and was not executed.", toolUse.Name),
+			ExecutedAt: &now,
+		}
+		db.DB.Create(&step)
+		ws.GlobalHub.Broadcast(agentRoom(run.ID), "step_updated", gin.H{"run_id": run.ID, "step": step})
+		doAgentTurn(run)
+		return
+	}
+
+	step := models.AgentStep{
+		AgentRunID: run.ID,
+		StepNumber: nextStepNumber,
+		Kind:       kind,
+		ToolName:   toolUse.Name,
+		ToolArgs:   string(toolUse.Input),
+		ToolUseID:  toolUse.ID,
+		Reasoning:  reasoning,
+		Status:     "pending_approval",
+	}
+	db.DB.Create(&step)
+	run.Status = "awaiting_approval"
+	db.DB.Save(run)
+	ws.GlobalHub.Broadcast(agentRoom(run.ID), "step_created", gin.H{"run_id": run.ID, "step": step})
+}
+
+// executeAgentStep runs the approved step's tool call and records the real
+// output/error on it. Only called after explicit human approval.
+func executeAgentStep(run *models.AgentRun, step *models.AgentStep) {
+	now := time.Now()
+
+	switch step.Kind {
+	case "ssh_command":
+		var args struct {
+			ServerID uint   `json:"server_id"`
+			Command  string `json:"command"`
+		}
+		if err := json.Unmarshal([]byte(step.ToolArgs), &args); err != nil {
+			step.Status = "failed"
+			step.ErrorText = fmt.Sprintf("invalid tool arguments: %v", err)
+			break
+		}
+		if args.ServerID != run.ServerID {
+			step.Status = "failed"
+			step.ErrorText = fmt.Sprintf("refused: server_id %d does not match this run's server %d", args.ServerID, run.ServerID)
+			break
+		}
+		var server models.Server
+		if err := db.DB.First(&server, run.ServerID).Error; err != nil {
+			step.Status = "failed"
+			step.ErrorText = "target server not found"
+			break
+		}
+		client, err := sshclient.GetOrCreate(server.ID, server.Host, server.Port, server.SSHUser, server.SSHKeyPath, server.SSHPassword, server.AuthType)
+		if err != nil {
+			step.Status = "failed"
+			step.ErrorText = fmt.Sprintf("SSH connect error: %v", err)
+			break
+		}
+		stdout, stderr, err := client.RunCommandTimeout(args.Command, 30*time.Second)
+		if err != nil {
+			step.Status = "failed"
+			step.ErrorText = fmt.Sprintf("Error: %v\nStderr: %s\nStdout: %s", err, stderr, stdout)
+		} else {
+			step.Status = "executed"
+			step.Output = stdout
+			if stderr != "" {
+				step.Output += "\n[stderr]\n" + stderr
+			}
+		}
+	case "mcp_tool":
+		var args map[string]interface{}
+		if step.ToolArgs != "" {
+			_ = json.Unmarshal([]byte(step.ToolArgs), &args)
+		}
+		output, isError, err := executeMCPToolInternal(run.ServerID, step.ToolName, args)
+		if err != nil {
+			step.Status = "failed"
+			step.ErrorText = err.Error()
+		} else if isError {
+			step.Status = "failed"
+			step.ErrorText = output
+		} else {
+			step.Status = "executed"
+			step.Output = output
+		}
+	default:
+		step.Status = "failed"
+		step.ErrorText = "unsupported step kind"
+	}
+
+	step.ExecutedAt = &now
+	db.DB.Save(step)
+}
+
+// ── HTTP handlers ────────────────────────────────────────────────────────────
+
+func loadOwnedAgentRun(c *gin.Context) (models.AgentRun, bool) {
+	var run models.AgentRun
+	if err := db.DB.First(&run, c.Param("id")).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "agent run not found"})
+		return run, false
+	}
+	role := c.GetString("role")
+	userID := c.GetUint("user_id")
+	if run.UserID != userID && role != "admin" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "you do not have access to this agent run"})
+		return run, false
+	}
+	return run, true
+}
+
+func loadAgentRunWithSteps(runID uint) models.AgentRun {
+	var run models.AgentRun
+	db.DB.First(&run, runID)
+	var steps []models.AgentStep
+	db.DB.Where("agent_run_id = ?", runID).Order("step_number ASC").Find(&steps)
+	run.Steps = steps
+	return run
+}
+
+// CreateAgentRun — POST /api/agent/runs
+func CreateAgentRun(c *gin.Context) {
+	var req struct {
+		Goal     string `json:"goal" binding:"required"`
+		ServerID uint   `json:"server_id" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	role := c.GetString("role")
+	userID := c.GetUint("user_id")
+
+	if !HasServerAccess(role, userID, req.ServerID) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "you have not been granted access to this server"})
+		return
+	}
+
+	var user models.User
+	if err := db.DB.First(&user, userID).Error; err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not found"})
+		return
+	}
+	if user.ClaudeKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Set your Claude API key in Settings → AI to use the Agent"})
+		return
+	}
+
+	if err := db.DB.First(&models.Server{}, req.ServerID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "server not found"})
+		return
+	}
+
+	run := models.AgentRun{
+		UserID:    userID,
+		ServerID:  req.ServerID,
+		Goal:      req.Goal,
+		Status:    "running",
+		Provider:  "claude",
+		Model:     agent.ClaudeModel,
+		StartedAt: time.Now(),
+	}
+	if err := db.DB.Create(&run).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create agent run"})
+		return
+	}
+
+	doAgentTurn(&run)
+
+	c.JSON(http.StatusCreated, loadAgentRunWithSteps(run.ID))
+}
+
+// ListAgentRuns — GET /api/agent/runs
+func ListAgentRuns(c *gin.Context) {
+	userID := c.GetUint("user_id")
+	var runs []models.AgentRun
+	db.DB.Where("user_id = ?", userID).Order("created_at DESC").Find(&runs)
+	c.JSON(http.StatusOK, runs)
+}
+
+// GetAgentRun — GET /api/agent/runs/:id
+func GetAgentRun(c *gin.Context) {
+	run, ok := loadOwnedAgentRun(c)
+	if !ok {
+		return
+	}
+	c.JSON(http.StatusOK, loadAgentRunWithSteps(run.ID))
+}
+
+// ApproveAgentStep — POST /api/agent/runs/:id/steps/:stepId/approve
+func ApproveAgentStep(c *gin.Context) {
+	run, ok := loadOwnedAgentRun(c)
+	if !ok {
+		return
+	}
+	if run.Status != "awaiting_approval" {
+		c.JSON(http.StatusConflict, gin.H{"error": "run is not awaiting approval"})
+		return
+	}
+
+	var step models.AgentStep
+	if err := db.DB.Where("id = ? AND agent_run_id = ?", c.Param("stepId"), run.ID).First(&step).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "step not found"})
+		return
+	}
+	if step.Status != "pending_approval" {
+		c.JSON(http.StatusConflict, gin.H{"error": "step is not pending approval"})
+		return
+	}
+
+	userID := c.GetUint("user_id")
+	now := time.Now()
+	step.DecidedByUserID = &userID
+	step.DecidedAt = &now
+
+	executeAgentStep(&run, &step)
+	ws.GlobalHub.Broadcast(agentRoom(run.ID), "step_updated", gin.H{"run_id": run.ID, "step": step})
+
+	run.Status = "running"
+	db.DB.Save(&run)
+
+	doAgentTurn(&run)
+
+	c.JSON(http.StatusOK, loadAgentRunWithSteps(run.ID))
+}
+
+// RejectAgentStep — POST /api/agent/runs/:id/steps/:stepId/reject
+func RejectAgentStep(c *gin.Context) {
+	run, ok := loadOwnedAgentRun(c)
+	if !ok {
+		return
+	}
+	if run.Status != "awaiting_approval" {
+		c.JSON(http.StatusConflict, gin.H{"error": "run is not awaiting approval"})
+		return
+	}
+
+	var step models.AgentStep
+	if err := db.DB.Where("id = ? AND agent_run_id = ?", c.Param("stepId"), run.ID).First(&step).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "step not found"})
+		return
+	}
+	if step.Status != "pending_approval" {
+		c.JSON(http.StatusConflict, gin.H{"error": "step is not pending approval"})
+		return
+	}
+
+	userID := c.GetUint("user_id")
+	now := time.Now()
+	step.Status = "rejected"
+	step.DecidedByUserID = &userID
+	step.DecidedAt = &now
+	step.ExecutedAt = &now
+	db.DB.Save(&step)
+	ws.GlobalHub.Broadcast(agentRoom(run.ID), "step_updated", gin.H{"run_id": run.ID, "step": step})
+
+	run.Status = "running"
+	db.DB.Save(&run)
+
+	doAgentTurn(&run)
+
+	c.JSON(http.StatusOK, loadAgentRunWithSteps(run.ID))
+}
+
+// CancelAgentRun — POST /api/agent/runs/:id/cancel
+func CancelAgentRun(c *gin.Context) {
+	run, ok := loadOwnedAgentRun(c)
+	if !ok {
+		return
+	}
+	if run.Status != "running" && run.Status != "awaiting_approval" {
+		c.JSON(http.StatusConflict, gin.H{"error": "run is not active"})
+		return
+	}
+
+	now := time.Now()
+	db.DB.Model(&models.AgentStep{}).
+		Where("agent_run_id = ? AND status = ?", run.ID, "pending_approval").
+		Updates(map[string]interface{}{"status": "rejected", "executed_at": now})
+
+	run.Status = "cancelled"
+	run.FinishedAt = &now
+	db.DB.Save(&run)
+	ws.GlobalHub.Broadcast(agentRoom(run.ID), "run_cancelled", gin.H{"run_id": run.ID, "status": run.Status})
+
+	c.JSON(http.StatusOK, loadAgentRunWithSteps(run.ID))
+}
+
+// AgentRunWS subscribes a client to live updates for one agent run.
+func AgentRunWS(c *gin.Context) {
+	run, ok := loadOwnedAgentRun(c)
+	if !ok {
+		return
+	}
+	conn, err := UpgradeConn(c.Writer, c.Request)
+	if err != nil {
+		return
+	}
+	client := ws.GlobalHub.Register(conn, agentRoom(run.ID))
+	client.ReadPump(ws.GlobalHub, nil)
+}

--- a/backend/internal/handlers/mcp.go
+++ b/backend/internal/handlers/mcp.go
@@ -32,7 +32,6 @@ var mcpSSEClient = &http.Client{Timeout: 0}
 // while a wrong process is bound to the configured port.
 var mcpStatusClient = &http.Client{Timeout: 5 * time.Second}
 
-
 // ── MCP JSON-RPC types ─────────────────────────────────────────────────────
 
 type mcpRequest struct {
@@ -87,18 +86,40 @@ func ExecuteMCPTool(c *gin.Context) {
 		return
 	}
 
+	output, isError, err := executeMCPToolInternal(req.ServerID, req.Tool, req.Arguments)
+	if err != nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error":   "MCP tool execution failed",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"tool":     req.Tool,
+		"output":   output,
+		"is_error": isError,
+		"success":  !isError,
+	})
+}
+
+// executeMCPToolInternal runs an MCP tool call against the sidecar, injecting
+// the target server's kubeconfig context when serverID has one, and returns
+// the concatenated text output. It is the shared implementation behind both
+// ExecuteMCPTool and the Agent orchestrator's mcp_tool step execution.
+func executeMCPToolInternal(serverID uint, toolName string, args map[string]interface{}) (output string, isError bool, err error) {
 	// If a server_id is provided and it has a kubeconfig, inject the context
-	if req.ServerID > 0 {
+	if serverID > 0 {
 		var server models.Server
-		if err := db.DB.First(&server, req.ServerID).Error; err == nil && server.KubeConfig != "" {
-			if req.Arguments == nil {
-				req.Arguments = map[string]interface{}{}
+		if dbErr := db.DB.First(&server, serverID).Error; dbErr == nil && server.KubeConfig != "" {
+			if args == nil {
+				args = map[string]interface{}{}
 			}
 
 			// Load the config to find the correct context name
 			prefix := fmt.Sprintf("server-%d", server.ID)
-			cfg, err := clientcmd.Load([]byte(server.KubeConfig))
-			if err == nil {
+			cfg, cfgErr := clientcmd.Load([]byte(server.KubeConfig))
+			if cfgErr == nil {
 				selectedCtx := ""
 				if cfg.CurrentContext != "" {
 					selectedCtx = fmt.Sprintf("%s-%s", prefix, cfg.CurrentContext)
@@ -112,26 +133,22 @@ func ExecuteMCPTool(c *gin.Context) {
 				if selectedCtx == "" {
 					selectedCtx = prefix + "-default"
 				}
-				req.Arguments["context"] = selectedCtx
+				args["context"] = selectedCtx
 			} else {
 				// Fallback if load fails
-				req.Arguments["context"] = prefix + "-default"
+				args["context"] = prefix + "-default"
 			}
 		}
 	}
 
 	params := mcpToolCallParams{
-		Name:      req.Tool,
-		Arguments: req.Arguments,
+		Name:      toolName,
+		Arguments: args,
 	}
 
 	result, err := callMCPMethod("tools/call", params, 1)
 	if err != nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{
-			"error":   "MCP tool execution failed",
-			"details": err.Error(),
-		})
-		return
+		return "", false, err
 	}
 
 	// Parse and re-emit the result content
@@ -142,25 +159,18 @@ func ExecuteMCPTool(c *gin.Context) {
 		} `json:"content"`
 		IsError bool `json:"isError"`
 	}
-	if err := json.Unmarshal(result, &parsed); err != nil {
-		// Return raw result if parsing fails
-		c.Data(http.StatusOK, "application/json", result)
-		return
+	if unmarshalErr := json.Unmarshal(result, &parsed); unmarshalErr != nil {
+		// Fall back to the raw JSON-RPC result if it doesn't match the expected shape
+		return string(result), false, nil
 	}
 
-	output := ""
 	for _, content := range parsed.Content {
 		if content.Type == "text" {
 			output += content.Text
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"tool":     req.Tool,
-		"output":   output,
-		"is_error": parsed.IsError,
-		"success":  !parsed.IsError,
-	})
+	return output, parsed.IsError, nil
 }
 
 // ── MCPServerStatus ─────────────────────────────────────────────────────────

--- a/backend/internal/httpapi/routes.go
+++ b/backend/internal/httpapi/routes.go
@@ -136,6 +136,14 @@ func RegisterRoutes(r *gin.Engine) {
 		api.POST("/mcp/tool", middleware.RequireRole("admin", "devops"), handlers.ExecuteMCPTool)
 		api.POST("/mcp/kubectl", middleware.RequireRole("admin", "devops"), handlers.RunKubectlViaMCP)
 
+		// ── Agent (multi-turn, human-approved DevOps automation) ──
+		api.POST("/agent/runs", middleware.RequireRole("admin", "devops"), handlers.CreateAgentRun)
+		api.GET("/agent/runs", middleware.RequireRole("admin", "devops"), handlers.ListAgentRuns)
+		api.GET("/agent/runs/:id", middleware.RequireRole("admin", "devops"), handlers.GetAgentRun)
+		api.POST("/agent/runs/:id/steps/:stepId/approve", middleware.RequireRole("admin", "devops"), handlers.ApproveAgentStep)
+		api.POST("/agent/runs/:id/steps/:stepId/reject", middleware.RequireRole("admin", "devops"), handlers.RejectAgentStep)
+		api.POST("/agent/runs/:id/cancel", middleware.RequireRole("admin", "devops"), handlers.CancelAgentRun)
+
 		// ── Alert rules ───────────────────────────────────────────
 		api.GET("/alert-rules", middleware.RequireRole("admin", "devops", "trainee"), handlers.ListAlertRules)
 		api.POST("/alert-rules", middleware.RequireRole("admin", "devops"), handlers.CreateAlertRule)
@@ -176,6 +184,7 @@ func RegisterRoutes(r *gin.Engine) {
 		ws.GET("/servers/:id/kubectl/node-terminal", middleware.RequireRole("admin", "devops"), handlers.RunNodeTerminal)
 		ws.GET("/servers/:id/k8s/watch", middleware.RequireRole("admin", "devops", "trainee", "intern"), handlers.WatchKubectl)
 		ws.GET("/alerts", alertsWsHandler)
+		ws.GET("/agent/runs/:id", middleware.RequireRole("admin", "devops"), handlers.AgentRunWS)
 		ws.GET("/metrics/all", allMetricsWsHandler)
 	}
 }

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -257,6 +257,45 @@ type ChatThread struct {
 	ServerID  uint      `gorm:"index" json:"server_id"`
 }
 
+// AgentRun is one goal-driven, multi-turn Claude tool-calling session against
+// a single server. Each turn proposes at most one tool call (ssh_command or
+// an MCP/Kubernetes tool), which is only executed after explicit human
+// approval of the corresponding AgentStep.
+type AgentRun struct {
+	ID         uint        `gorm:"primaryKey" json:"id"`
+	UserID     uint        `gorm:"index" json:"user_id"`
+	ServerID   uint        `gorm:"index" json:"server_id"`
+	Goal       string      `gorm:"type:text" json:"goal"`
+	Status     string      `gorm:"default:running" json:"status"` // running, awaiting_approval, completed, failed, cancelled
+	Provider   string      `json:"provider"`                      // "claude" for v1
+	Model      string      `json:"model"`
+	StartedAt  time.Time   `json:"started_at"`
+	FinishedAt *time.Time  `json:"finished_at"`
+	ErrorText  string      `gorm:"type:text" json:"error_text"`
+	Steps      []AgentStep `gorm:"foreignKey:AgentRunID" json:"steps,omitempty"`
+	CreatedAt  time.Time   `gorm:"index" json:"created_at"`
+	UpdatedAt  time.Time   `json:"updated_at"`
+}
+
+// AgentStep is one proposed action (or the final answer) within an AgentRun.
+type AgentStep struct {
+	ID              uint       `gorm:"primaryKey" json:"id"`
+	AgentRunID      uint       `gorm:"index;uniqueIndex:idx_run_step" json:"agent_run_id"`
+	StepNumber      int        `gorm:"uniqueIndex:idx_run_step" json:"step_number"`
+	Kind            string     `json:"kind"` // ssh_command, mcp_tool, final_answer, unknown_tool
+	ToolName        string     `json:"tool_name"`
+	ToolArgs        string     `gorm:"type:text" json:"tool_args"` // JSON-marshaled map
+	ToolUseID       string     `json:"tool_use_id"`                // Claude's tool_use block id
+	Reasoning       string     `gorm:"type:text" json:"reasoning"` // assistant text preceding the tool call, or the final answer
+	Status          string     `json:"status"`                     // pending_approval, approved, rejected, executed, failed
+	Output          string     `gorm:"type:text" json:"output"`
+	ErrorText       string     `gorm:"type:text" json:"error_text"`
+	DecidedByUserID *uint      `json:"decided_by_user_id"`
+	DecidedAt       *time.Time `json:"decided_at"`
+	ExecutedAt      *time.Time `json:"executed_at"`
+	CreatedAt       time.Time  `json:"created_at"`
+}
+
 // AppSetting is a platform-wide key/value setting configured from the UI
 // (e.g. notification webhook URLs). A stored value overrides the matching
 // environment-variable default.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Dashboard } from './pages/Dashboard'
 import { Servers } from './pages/Servers'
 import { ServerDetail } from './pages/ServerDetail'
 import { AIAssistant } from './pages/AIAssistant'
+import { Agent } from './pages/Agent'
 import { AlertRules } from './pages/AlertRules'
 import { Settings } from './pages/Settings'
 import { Resources } from './pages/Resources'
@@ -42,6 +43,7 @@ export default function App() {
           <Route path="terminal" element={<Navigate to="/" />} />
           <Route path="kubectl" element={<Navigate to="/" />} />
           <Route path="ai" element={<AIAssistant />} />
+          <Route path="agent" element={<Agent />} />
           <Route path="alerts" element={<AlertRules />} />
           <Route path="settings" element={<Settings />} />
           <Route path="kubernetes" element={<Kubernetes />} />

--- a/frontend/src/components/agent/RunSidebar.tsx
+++ b/frontend/src/components/agent/RunSidebar.tsx
@@ -1,0 +1,224 @@
+import { memo, useState, useEffect, useCallback } from 'react'
+import { X, ChevronLeft, ChevronRight, Plus, Workflow } from 'lucide-react'
+
+export interface AgentRunSummary {
+  id: number
+  goal: string
+  status: 'running' | 'awaiting_approval' | 'completed' | 'failed' | 'cancelled'
+  created_at: string
+}
+
+interface RunSidebarProps {
+  runs: AgentRunSummary[]
+  activeRunId: number | null
+  onSelect: (id: number) => void
+  onNew: () => void
+  isCollapsed: boolean
+  onToggle: (v: boolean) => void
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  if (isNaN(diff) || diff < 0) return ''
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+const STATUS_COLOR: Record<AgentRunSummary['status'], string> = {
+  running: 'var(--brand-primary)',
+  awaiting_approval: 'var(--warning, #d97706)',
+  completed: 'var(--success)',
+  failed: 'var(--danger)',
+  cancelled: 'var(--text-muted)',
+}
+
+const STATUS_LABEL: Record<AgentRunSummary['status'], string> = {
+  running: 'Running',
+  awaiting_approval: 'Needs approval',
+  completed: 'Completed',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+}
+
+export const RunSidebar = memo(({
+  runs, activeRunId, onSelect, onNew, isCollapsed, onToggle,
+}: RunSidebarProps) => {
+  const [width, setWidth] = useState(280)
+  const [isResizing, setIsResizing] = useState(false)
+
+  const startResizing = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    setIsResizing(true)
+  }, [])
+
+  const stopResizing = useCallback(() => setIsResizing(false), [])
+
+  const resize = useCallback((e: MouseEvent) => {
+    if (isResizing) {
+      const newWidth = e.clientX
+      if (newWidth > 180 && newWidth < 600) setWidth(newWidth)
+    }
+  }, [isResizing])
+
+  useEffect(() => {
+    window.addEventListener('mousemove', resize)
+    window.addEventListener('mouseup', stopResizing)
+    return () => {
+      window.removeEventListener('mousemove', resize)
+      window.removeEventListener('mouseup', stopResizing)
+    }
+  }, [resize, stopResizing])
+
+  const sidebarWidth = isCollapsed ? 64 : width
+
+  return (
+    <div
+      className={`ai-sidebar ${isCollapsed ? 'collapsed' : ''}`}
+      style={{
+        width: sidebarWidth,
+        borderRight: '1px solid var(--border)',
+        background: 'var(--bg-sidebar)', display: 'flex', flexDirection: 'column',
+        flexShrink: 0, transition: isResizing ? 'none' : 'width 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        overflow: 'hidden', position: 'relative', zIndex: 100,
+      }}
+    >
+      {!isCollapsed && (
+        <button
+          className="show-mobile-only btn-icon"
+          onClick={() => onToggle(true)}
+          style={{ position: 'absolute', right: 12, top: 28, zIndex: 10, background: 'var(--bg-elevated)', border: '1px solid var(--border)' }}
+        >
+          <X size={16} />
+        </button>
+      )}
+      {!isCollapsed && (
+        <div
+          onMouseDown={startResizing}
+          style={{
+            position: 'absolute', right: 0, top: 0, bottom: 0, width: 4,
+            cursor: 'col-resize', zIndex: 10,
+            background: isResizing ? 'var(--brand-primary)' : 'transparent',
+            transition: 'background 0.2s',
+          }}
+          onMouseEnter={e => !isResizing && (e.currentTarget.style.background = 'var(--border-bright)')}
+          onMouseLeave={e => !isResizing && (e.currentTarget.style.background = 'transparent')}
+        />
+      )}
+
+      <div style={{ padding: '20px 14px 14px', display: 'flex', flexDirection: 'column', gap: 14, alignItems: isCollapsed ? 'center' : 'stretch' }}>
+        <div style={{ display: 'flex', justifyContent: isCollapsed ? 'center' : 'space-between', alignItems: 'center', gap: 8 }}>
+          {!isCollapsed ? (
+            <>
+              <button
+                onClick={onNew}
+                style={{
+                  flex: 1, height: 40, borderRadius: 'var(--radius-md)',
+                  background: 'var(--brand-primary)', border: 'none',
+                  color: 'var(--text-inverse)', fontSize: 13.5, fontWeight: 800,
+                  cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+                  transition: 'filter 0.1s', padding: '0 14px',
+                }}
+                onMouseEnter={e => e.currentTarget.style.filter = 'brightness(1.1)'}
+                onMouseLeave={e => e.currentTarget.style.filter = 'none'}
+              >
+                <Plus size={15} strokeWidth={3} />
+                <span>New agent run</span>
+              </button>
+              <button
+                onClick={() => onToggle(true)}
+                title="Collapse sidebar"
+                style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border)', padding: 6, borderRadius: 'var(--radius-md)', cursor: 'pointer', color: 'var(--text-muted)', flexShrink: 0 }}
+              >
+                <ChevronLeft size={16} />
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={onNew}
+              title="New agent run"
+              style={{
+                width: 40, height: 40, borderRadius: 'var(--radius-md)',
+                background: 'var(--brand-primary)', border: 'none',
+                color: 'var(--text-inverse)', cursor: 'pointer', display: 'flex',
+                alignItems: 'center', justifyContent: 'center',
+              }}
+            >
+              <Plus size={18} strokeWidth={3} />
+            </button>
+          )}
+        </div>
+
+        {isCollapsed && (
+          <button
+            onClick={() => onToggle(false)}
+            title="Expand sidebar"
+            style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 'var(--radius-md)', padding: 6, cursor: 'pointer', color: 'var(--text-muted)' }}
+          >
+            <ChevronRight size={16} />
+          </button>
+        )}
+
+        {!isCollapsed && runs.length > 0 && (
+          <div style={{ fontSize: 12, fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--text-muted)', padding: '0 4px' }}>
+            Runs
+          </div>
+        )}
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: isCollapsed ? '0 8px' : '0 10px 20px', display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {!isCollapsed && runs.length === 0 && (
+          <div style={{ padding: '24px 12px', textAlign: 'center', color: 'var(--text-muted)' }}>
+            <Workflow size={22} style={{ opacity: 0.4, marginBottom: 8 }} />
+            <div style={{ fontSize: 12.5, fontWeight: 600, lineHeight: 1.5 }}>No agent runs yet — describe a goal to start one.</div>
+          </div>
+        )}
+        {runs.map(r => (
+          <div
+            key={r.id}
+            onClick={() => onSelect(r.id)}
+            title={isCollapsed ? r.goal : undefined}
+            className="ai-thread-item"
+            style={{
+              padding: isCollapsed ? '12px 0' : '10px 12px', borderRadius: 'var(--radius-md)', cursor: 'pointer',
+              display: 'flex', alignItems: 'center',
+              background: activeRunId === r.id ? 'var(--bg-elevated)' : 'transparent',
+              boxShadow: activeRunId === r.id ? 'inset 2px 0 0 var(--brand-primary)' : 'none',
+              transition: 'background 0.15s',
+              justifyContent: isCollapsed ? 'center' : 'flex-start',
+              gap: 8, position: 'relative', overflow: 'hidden',
+            }}
+            onMouseEnter={e => { if (activeRunId !== r.id) e.currentTarget.style.background = 'var(--bg-elevated)' }}
+            onMouseLeave={e => { if (activeRunId !== r.id) e.currentTarget.style.background = 'transparent' }}
+          >
+            {!isCollapsed ? (
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{
+                  fontSize: 13.5, color: activeRunId === r.id ? 'var(--text-primary)' : 'var(--text-secondary)',
+                  fontWeight: activeRunId === r.id ? 700 : 600,
+                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                }}>
+                  {r.goal}
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3 }}>
+                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: STATUS_COLOR[r.status], flexShrink: 0 }} />
+                  <span style={{ fontSize: 11.5, color: STATUS_COLOR[r.status], fontWeight: 700 }}>{STATUS_LABEL[r.status]}</span>
+                  <span style={{ fontSize: 11.5, color: 'var(--text-muted)', fontWeight: 600 }}>· {timeAgo(r.created_at)}</span>
+                </div>
+              </div>
+            ) : (
+              <div style={{ width: 8, height: 8, borderRadius: '50%', background: STATUS_COLOR[r.status] }} />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+})
+
+RunSidebar.displayName = 'RunSidebar'

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@ import {
   LayoutDashboard, Server, Boxes,
   Bot, Bell, Settings, LogOut, ChevronRight,
   ChevronLeft, Menu, Code2, Sun, Moon, ChevronDown, Shield, Database, X,
-  ShieldAlert, Lock, Network, KeyRound, GitBranch, Download
+  ShieldAlert, Lock, Network, KeyRound, GitBranch, Download, Workflow
 } from 'lucide-react'
 import { useAuthStore } from '../../store/authStore'
 import { useUIStore } from '../../store/uiStore'
@@ -43,6 +43,7 @@ const navGroups: { label: string; items: NavItem[] }[] = [
     label: 'Operations',
     items: [
       { to: '/ai',         icon: Bot,             label: 'AI Assistant', action: 'use-ai' },
+      { to: '/agent',      icon: Workflow,        label: 'Agent',        action: 'use-agent' },
     ]
   },
   {

--- a/frontend/src/hooks/usePermission.ts
+++ b/frontend/src/hooks/usePermission.ts
@@ -7,6 +7,7 @@ export type PermissionAction =
   | 'use-terminal'
   | 'use-kubectl'
   | 'use-ai'
+  | 'use-agent'
   | 'manage-alerts'
   | 'manage-resources'
   | 'manage-users'
@@ -32,6 +33,8 @@ export function usePermission() {
       case 'use-kubectl':
         return ['admin', 'devops'].includes(role)
       case 'use-ai':
+        return ['admin', 'devops'].includes(role)
+      case 'use-agent':
         return ['admin', 'devops'].includes(role)
       case 'manage-alerts':
         return ['admin', 'devops'].includes(role)

--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -1,0 +1,464 @@
+import { useState, useEffect, useRef, useCallback, memo } from 'react'
+import {
+  Send, ChevronDown, Menu, Workflow, Terminal, Boxes, Bot,
+  CheckCircle2, XCircle, AlertTriangle, Ban, Loader, Check, X, StopCircle,
+} from 'lucide-react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { api, buildWsUrl } from '../api/client'
+import { useToastStore } from '../store/toastStore'
+import { RunSidebar, type AgentRunSummary } from '../components/agent/RunSidebar'
+
+interface ServerData { id: number; name: string; is_k8s?: boolean }
+
+interface AgentStep {
+  id: number
+  agent_run_id: number
+  step_number: number
+  kind: 'ssh_command' | 'mcp_tool' | 'final_answer' | 'unknown_tool'
+  tool_name: string
+  tool_args: string
+  reasoning: string
+  status: 'pending_approval' | 'approved' | 'rejected' | 'executed' | 'failed'
+  output: string
+  error_text: string
+  executed_at?: string
+}
+
+interface AgentRun extends AgentRunSummary {
+  server_id: number
+  provider: string
+  model: string
+  started_at: string
+  finished_at?: string
+  error_text: string
+  steps: AgentStep[]
+}
+
+const STATUS_BADGE: Record<AgentRun['status'], { label: string; color: string }> = {
+  running: { label: 'Running', color: 'var(--brand-primary)' },
+  awaiting_approval: { label: 'Needs your approval', color: 'var(--warning, #d97706)' },
+  completed: { label: 'Completed', color: 'var(--success)' },
+  failed: { label: 'Failed', color: 'var(--danger)' },
+  cancelled: { label: 'Cancelled', color: 'var(--text-muted)' },
+}
+
+function prettyArgs(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2)
+  } catch {
+    return raw
+  }
+}
+
+function kindMeta(kind: AgentStep['kind']) {
+  switch (kind) {
+    case 'ssh_command': return { label: 'SSH command', icon: Terminal, color: 'var(--info, #3b82f6)' }
+    case 'mcp_tool': return { label: 'Kubernetes / MCP tool', icon: Boxes, color: 'var(--brand-primary)' }
+    case 'unknown_tool': return { label: 'Unknown tool', icon: Ban, color: 'var(--danger)' }
+    default: return { label: 'Final answer', icon: Bot, color: 'var(--success)' }
+  }
+}
+
+const StepCard = memo(({ step, isBusy, onApprove, onReject }: {
+  step: AgentStep
+  isBusy: boolean
+  onApprove: (id: number) => void
+  onReject: (id: number) => void
+}) => {
+  if (step.kind === 'final_answer') {
+    return (
+      <div className="fade-up" style={{ display: 'flex', gap: 14, alignItems: 'flex-start' }}>
+        <div style={{ width: 34, height: 34, borderRadius: 'var(--radius-md)', background: 'var(--bg-card)', border: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+          <Bot size={16} color="var(--success)" />
+        </div>
+        <div style={{ flex: 1, minWidth: 0, background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: '14px 16px' }}>
+          <div className="markdown-body" style={{ fontSize: 13.5, color: 'var(--text-primary)', lineHeight: 1.6 }}>
+            <Markdown remarkPlugins={[remarkGfm]}>{step.reasoning}</Markdown>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const meta = kindMeta(step.kind)
+  const Icon = meta.icon
+
+  return (
+    <div className="fade-up" style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', overflow: 'hidden' }}>
+      <div style={{ padding: '14px 16px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: 10 }}>
+        <span style={{ fontSize: 11.5, fontWeight: 800, color: 'var(--text-muted)', flexShrink: 0 }}>#{step.step_number}</span>
+        <Icon size={15} color={meta.color} />
+        <span style={{ fontSize: 12.5, fontWeight: 800, color: meta.color, textTransform: 'uppercase', letterSpacing: '0.04em' }}>{meta.label}</span>
+        {step.tool_name && (
+          <code style={{ fontSize: 12, color: 'var(--text-secondary)', background: 'var(--bg-elevated)', padding: '2px 8px', borderRadius: 6 }}>{step.tool_name}</code>
+        )}
+        <div style={{ flex: 1 }} />
+        {step.status === 'pending_approval' && <span style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--warning, #d97706)' }}>Awaiting approval</span>}
+        {step.status === 'executed' && <CheckCircle2 size={16} color="var(--success)" />}
+        {step.status === 'failed' && <AlertTriangle size={16} color="var(--danger)" />}
+        {step.status === 'rejected' && <XCircle size={16} color="var(--text-muted)" />}
+      </div>
+
+      <div style={{ padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {step.reasoning && (
+          <div className="markdown-body" style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.6 }}>
+            <Markdown remarkPlugins={[remarkGfm]}>{step.reasoning}</Markdown>
+          </div>
+        )}
+
+        {step.tool_args && (
+          <pre style={{ margin: 0, padding: '10px 12px', background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)', fontSize: 12, color: 'var(--text-secondary)', overflowX: 'auto', fontFamily: 'var(--font-mono, monospace)' }}>
+            {prettyArgs(step.tool_args)}
+          </pre>
+        )}
+
+        {step.status === 'pending_approval' && (
+          <div style={{ display: 'flex', gap: 10 }}>
+            <button
+              disabled={isBusy}
+              onClick={() => onApprove(step.id)}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px', borderRadius: 'var(--radius-md)',
+                background: 'var(--brand-primary)', color: 'var(--text-inverse)', border: 'none', fontSize: 13, fontWeight: 800,
+                cursor: isBusy ? 'default' : 'pointer', opacity: isBusy ? 0.6 : 1,
+              }}
+            >
+              {isBusy ? <Loader size={14} className="spin" /> : <Check size={14} strokeWidth={3} />}
+              Approve &amp; run
+            </button>
+            <button
+              disabled={isBusy}
+              onClick={() => onReject(step.id)}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px', borderRadius: 'var(--radius-md)',
+                background: 'var(--bg-elevated)', color: 'var(--text-secondary)', border: '1px solid var(--border)', fontSize: 13, fontWeight: 800,
+                cursor: isBusy ? 'default' : 'pointer', opacity: isBusy ? 0.6 : 1,
+              }}
+            >
+              <X size={14} strokeWidth={3} />
+              Reject
+            </button>
+          </div>
+        )}
+
+        {step.status === 'executed' && step.output && (
+          <pre style={{ margin: 0, padding: '10px 12px', background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)', fontSize: 12, color: 'var(--text-primary)', overflowX: 'auto', maxHeight: 320, overflowY: 'auto', fontFamily: 'var(--font-mono, monospace)' }}>
+            {step.output}
+          </pre>
+        )}
+
+        {step.status === 'failed' && step.error_text && (
+          <pre style={{ margin: 0, padding: '10px 12px', background: 'var(--bg-elevated)', border: '1px solid var(--danger)', borderRadius: 'var(--radius-md)', fontSize: 12, color: 'var(--danger)', overflowX: 'auto', maxHeight: 320, overflowY: 'auto', fontFamily: 'var(--font-mono, monospace)' }}>
+            {step.error_text}
+          </pre>
+        )}
+
+        {step.status === 'rejected' && (
+          <div style={{ fontSize: 12.5, color: 'var(--text-muted)', fontWeight: 600 }}>Rejected — not executed.</div>
+        )}
+      </div>
+    </div>
+  )
+})
+StepCard.displayName = 'StepCard'
+
+export function Agent() {
+  const [servers, setServers] = useState<ServerData[]>([])
+  const [selectedServer, setSelectedServer] = useState<number | ''>('')
+  const [runs, setRuns] = useState<AgentRunSummary[]>([])
+  const [activeRunId, setActiveRunId] = useState<number | null>(null)
+  const [activeRun, setActiveRun] = useState<AgentRun | null>(null)
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
+  const [goal, setGoal] = useState('')
+  const [starting, setStarting] = useState(false)
+  const [busyStepId, setBusyStepId] = useState<number | null>(null)
+  const [cancelling, setCancelling] = useState(false)
+  const [inputFocused, setInputFocused] = useState(false)
+
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const toast = useToastStore()
+
+  useEffect(() => {
+    api.get('/api/servers').then(res => setServers(res.data)).catch(() => {})
+  }, [])
+
+  const fetchRuns = useCallback(async () => {
+    try {
+      const res = await api.get('/api/agent/runs')
+      setRuns(res.data)
+    } catch (err) {
+      console.error('Failed to fetch agent runs', err)
+    }
+  }, [])
+
+  useEffect(() => { fetchRuns() }, [fetchRuns])
+
+  const fetchActiveRun = useCallback(async (id: number) => {
+    try {
+      const res = await api.get(`/api/agent/runs/${id}`)
+      setActiveRun(res.data)
+    } catch (err) {
+      console.error('Failed to fetch agent run', err)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (activeRunId == null) {
+      setActiveRun(null)
+      return
+    }
+    fetchActiveRun(activeRunId)
+  }, [activeRunId, fetchActiveRun])
+
+  useEffect(() => {
+    if (activeRunId == null) return
+    const socket = new WebSocket(buildWsUrl(`/ws/agent/runs/${activeRunId}`))
+    socket.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data)
+        if (['step_created', 'step_updated', 'run_completed', 'run_failed', 'run_cancelled'].includes(msg.type)) {
+          fetchActiveRun(activeRunId)
+          fetchRuns()
+        }
+      } catch (err) {
+        console.error('WS agent parse error', err)
+      }
+    }
+    return () => socket.close()
+  }, [activeRunId, fetchActiveRun, fetchRuns])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [activeRun?.steps.length])
+
+  const startRun = useCallback(async () => {
+    if (!goal.trim() || !selectedServer || starting) return
+    setStarting(true)
+    try {
+      const res = await api.post('/api/agent/runs', { goal: goal.trim(), server_id: Number(selectedServer) })
+      setGoal('')
+      setActiveRunId(res.data.id)
+      setActiveRun(res.data)
+      fetchRuns()
+    } catch (err: any) {
+      toast.error('Could not start agent run', err.response?.data?.error || err.message)
+    } finally {
+      setStarting(false)
+    }
+  }, [goal, selectedServer, starting, fetchRuns, toast])
+
+  const approveStep = useCallback(async (stepId: number) => {
+    if (!activeRunId) return
+    setBusyStepId(stepId)
+    try {
+      const res = await api.post(`/api/agent/runs/${activeRunId}/steps/${stepId}/approve`)
+      setActiveRun(res.data)
+      fetchRuns()
+    } catch (err: any) {
+      toast.error('Could not approve step', err.response?.data?.error || err.message)
+    } finally {
+      setBusyStepId(null)
+    }
+  }, [activeRunId, fetchRuns, toast])
+
+  const rejectStep = useCallback(async (stepId: number) => {
+    if (!activeRunId) return
+    setBusyStepId(stepId)
+    try {
+      const res = await api.post(`/api/agent/runs/${activeRunId}/steps/${stepId}/reject`)
+      setActiveRun(res.data)
+      fetchRuns()
+    } catch (err: any) {
+      toast.error('Could not reject step', err.response?.data?.error || err.message)
+    } finally {
+      setBusyStepId(null)
+    }
+  }, [activeRunId, fetchRuns, toast])
+
+  const cancelRun = useCallback(async () => {
+    if (!activeRunId) return
+    setCancelling(true)
+    try {
+      const res = await api.post(`/api/agent/runs/${activeRunId}/cancel`)
+      setActiveRun(res.data)
+      fetchRuns()
+    } catch (err: any) {
+      toast.error('Could not cancel run', err.response?.data?.error || err.message)
+    } finally {
+      setCancelling(false)
+    }
+  }, [activeRunId, fetchRuns, toast])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      startRun()
+    }
+  }
+
+  const selectStyle: React.CSSProperties = {
+    height: 34, padding: '0 26px 0 10px', borderRadius: 'var(--radius-md)',
+    background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+    color: 'var(--text-primary)', fontSize: 13, fontWeight: 700,
+    cursor: 'pointer', outline: 'none', appearance: 'none', WebkitAppearance: 'none',
+  }
+
+  const activeServerName = servers.find(s => s.id === activeRun?.server_id)?.name
+
+  return (
+    <div className={`ai-assistant-container ${isSidebarCollapsed ? 'sidebar-collapsed' : ''}`} style={{ display: 'flex', height: '100%', background: 'var(--bg-app)', position: 'relative' }}>
+      <div
+        className={`ai-sidebar-overlay ${!isSidebarCollapsed ? 'mobile-open' : ''}`}
+        onClick={() => setIsSidebarCollapsed(true)}
+      />
+
+      <RunSidebar
+        runs={runs}
+        activeRunId={activeRunId}
+        onSelect={id => { setActiveRunId(id); if (window.innerWidth <= 768) setIsSidebarCollapsed(true) }}
+        onNew={() => { setActiveRunId(null); if (window.innerWidth <= 768) setIsSidebarCollapsed(true) }}
+        isCollapsed={isSidebarCollapsed}
+        onToggle={setIsSidebarCollapsed}
+      />
+
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', position: 'relative', minWidth: 0 }}>
+        <header className="ai-chat-header" style={{
+          width: '100%', padding: '12px 20px',
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          flexShrink: 0, borderBottom: '1px solid var(--border)',
+          background: 'var(--bg-card)', flexWrap: 'wrap', gap: 12,
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <button
+              className="show-mobile-only btn-icon"
+              onClick={() => setIsSidebarCollapsed(false)}
+              title="Runs"
+              style={{ padding: 8, background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)', border: '1px solid var(--border)' }}
+            >
+              <Menu size={16} />
+            </button>
+            <div style={{
+              width: 38, height: 38, borderRadius: 'var(--radius-md)',
+              background: 'var(--brand-glow)', border: '1px solid var(--brand-primary)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>
+              <Workflow size={18} color="var(--brand-primary)" />
+            </div>
+            <div>
+              <h1 style={{ fontSize: 15, fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.01em', lineHeight: 1.2 }}>Agent</h1>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 600 }}>
+                Human-approved DevOps automation{activeServerName ? <> · <span style={{ color: 'var(--text-secondary)' }}>{activeServerName}</span></> : null}
+              </div>
+            </div>
+          </div>
+
+          {activeRun && (activeRun.status === 'running' || activeRun.status === 'awaiting_approval') && (
+            <button
+              onClick={cancelRun}
+              disabled={cancelling}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 6, padding: '8px 14px', borderRadius: 'var(--radius-md)',
+                background: 'var(--bg-elevated)', border: '1px solid var(--border)', color: 'var(--danger)',
+                fontSize: 12.5, fontWeight: 800, cursor: cancelling ? 'default' : 'pointer', opacity: cancelling ? 0.6 : 1,
+              }}
+            >
+              <StopCircle size={14} /> Cancel run
+            </button>
+          )}
+        </header>
+
+        <div style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', padding: '24px 16px 150px' }}>
+          <div style={{ maxWidth: 860, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16, minWidth: 0 }}>
+
+            {activeRun ? (
+              <>
+                <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1.5 }}>{activeRun.goal}</div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ width: 7, height: 7, borderRadius: '50%', background: STATUS_BADGE[activeRun.status].color }} />
+                    <span style={{ fontSize: 12, fontWeight: 800, color: STATUS_BADGE[activeRun.status].color }}>{STATUS_BADGE[activeRun.status].label}</span>
+                  </div>
+                  {activeRun.status === 'failed' && activeRun.error_text && (
+                    <div style={{ fontSize: 12.5, color: 'var(--danger)', fontWeight: 600 }}>{activeRun.error_text}</div>
+                  )}
+                </div>
+
+                {activeRun.steps.map(step => (
+                  <StepCard
+                    key={step.id}
+                    step={step}
+                    isBusy={busyStepId === step.id}
+                    onApprove={approveStep}
+                    onReject={rejectStep}
+                  />
+                ))}
+
+                {activeRun.status === 'running' && (
+                  <div style={{ display: 'flex', gap: 10, alignItems: 'center', color: 'var(--text-muted)', fontSize: 13, fontWeight: 600 }}>
+                    <Loader size={14} className="spin" /> Thinking…
+                  </div>
+                )}
+
+                <div ref={bottomRef} />
+              </>
+            ) : (
+              <div className="fade-in" style={{ padding: '8px 0 8px' }}>
+                <h2 style={{ fontSize: 13, color: 'var(--text-muted)', fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 14 }}>
+                  What should the Agent do?
+                </h2>
+                <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: 16, fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.6 }}>
+                  Describe a goal — e.g. "restart the nginx service" or "scale the checkout deployment to 3 replicas" —
+                  and pick the target server below. The Agent proposes one SSH or Kubernetes action at a time; nothing
+                  runs until you approve it.
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {!activeRun && (
+          <div className="ai-input-wrapper" style={{ position: 'absolute', bottom: 0, left: 0, right: 0, padding: '20px', background: 'linear-gradient(to top, var(--bg-app) 55%, transparent)', pointerEvents: 'none' }}>
+            <div style={{ maxWidth: 860, margin: '0 auto', pointerEvents: 'auto' }}>
+              <div className="chat-input-container" style={{
+                background: 'var(--bg-input)',
+                border: `1px solid ${inputFocused ? 'var(--brand-primary)' : 'var(--border)'}`,
+                borderRadius: 'var(--radius-lg)', padding: '12px 14px',
+                display: 'flex', gap: 10, alignItems: 'flex-end',
+                boxShadow: inputFocused ? '0 0 0 3px var(--brand-glow)' : 'var(--shadow-sm, none)',
+                transition: 'border-color 0.15s, box-shadow 0.15s',
+              }}>
+                <textarea
+                  value={goal} onChange={e => setGoal(e.target.value)} onKeyDown={handleKeyDown}
+                  onFocus={() => setInputFocused(true)} onBlur={() => setInputFocused(false)}
+                  placeholder="Describe the goal for the Agent…"
+                  disabled={starting} rows={1}
+                  style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', color: 'var(--text-primary)', fontSize: 13, padding: '8px 0', resize: 'none', lineHeight: 1.6, maxHeight: 150 }}
+                  onInput={e => { const el = e.currentTarget; el.style.height = 'auto'; el.style.height = Math.min(el.scrollHeight, 150) + 'px' }}
+                />
+                <div style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
+                  <select value={selectedServer} onChange={e => setSelectedServer(Number(e.target.value) || '')} title="Target server" style={{ ...selectStyle, maxWidth: 180 }}>
+                    <option value="">Select server…</option>
+                    {servers.map(s => <option key={s.id} value={s.id}>{s.is_k8s ? '☸ ' : ''}{s.name}</option>)}
+                  </select>
+                  <ChevronDown size={13} color="var(--text-muted)" style={{ position: 'absolute', right: 8, pointerEvents: 'none' }} />
+                </div>
+                <button onClick={startRun} disabled={!goal.trim() || !selectedServer || starting} title="Start agent run (Enter)"
+                  style={{ width: 38, height: 38, borderRadius: 'var(--radius-md)', flexShrink: 0, background: goal.trim() && selectedServer && !starting ? 'var(--brand-primary)' : 'var(--bg-elevated)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', border: 'none', transition: 'all 0.2s' }}>
+                  {starting ? <Loader size={16} className="spin" color="var(--text-muted)" /> : <Send size={16} color={goal.trim() && selectedServer ? 'var(--text-inverse)' : 'var(--text-muted)'} />}
+                </button>
+              </div>
+              <div className="hidden-mobile" style={{ display: 'flex', justifyContent: 'center', gap: 14, marginTop: 8, fontSize: 12.5, color: 'var(--text-muted)', fontWeight: 600 }}>
+                <span>Enter to start · Shift+Enter for a new line · every action needs your approval</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+      <style>{`
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        .spin { animation: spin 1s linear infinite; }
+      `}</style>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds a new Agent feature that drives a real multi-turn Claude tool-calling loop (native tools/tool_use/tool_result) against a goal, proposing one SSH or Kubernetes/MCP action per turn and executing only after explicit human approval, with live WS updates.

Backend: new AgentRun/AgentStep models, a leaf `agent` package wrapping the Claude Messages API tool-calling wire format, orchestration handlers (backend/internal/handlers/agent.go) reusing buildContext/HasServerAccess/ SSH client/MCP tool execution, and REST + WS routes gated to admin/devops. executeMCPToolInternal was extracted out of mcp.go so both the manual MCP button and the agent loop share the same execution path.

Frontend: Agent sidebar entry + route, use-agent permission, RunSidebar (run history) and Agent.tsx (goal input, live step timeline with Approve/Reject actions).