### PR TITLE
chore: bump version to 1.6.5

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.4",
+  "version": "1.6.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Ships the Agent feature (#112) — human-approved multi-turn DevOps orchestration via Claude tool-calling.

Bumps `frontend/package.json` / `package-lock.json` 1.6.4 → 1.6.5 so the desktop release build (triggered by pushing `desktop-v1.6.5` after this merges) reports the correct version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)