### PR TITLE
feat(agent): node-graph launcher, multi-provider dispatch, run delete + null-steps crash fix

### DIFF
--- a/backend/internal/agent/localllm.go
+++ b/backend/internal/agent/localllm.go
@@ -1,0 +1,225 @@
+// Local LLM tool-calling client: talks to a self-hosted, OpenAI-compatible
+// chat endpoint (Ollama, LM Studio, llama.cpp server, vLLM) using the OpenAI
+// function-calling wire format, and translates to/from the same generic
+// Message/ContentBlock/TurnResult shapes CallClaude uses — so doAgentTurn's
+// orchestration logic (buildMessageHistory, tool dispatch, step creation)
+// stays provider-agnostic.
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type openAIFunctionDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+type openAIToolDef struct {
+	Type     string            `json:"type"`
+	Function openAIFunctionDef `json:"function"`
+}
+
+type openAIFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type openAIToolCall struct {
+	ID       string             `json:"id"`
+	Type     string             `json:"type"`
+	Function openAIFunctionCall `json:"function"`
+}
+
+type openAIChatMessage struct {
+	Role       string           `json:"role"`
+	Content    *string          `json:"content"`
+	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+type localLLMRequest struct {
+	Model    string              `json:"model"`
+	Messages []openAIChatMessage `json:"messages"`
+	Tools    []openAIToolDef     `json:"tools,omitempty"`
+}
+
+type localLLMResponse struct {
+	Choices []struct {
+		Message openAIChatMessage `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func toOpenAIMessages(systemPrompt string, messages []Message) []openAIChatMessage {
+	out := []openAIChatMessage{{Role: "system", Content: &systemPrompt}}
+
+	for _, m := range messages {
+		var text string
+		var toolUse *ContentBlock
+		var toolResult *ContentBlock
+		for i := range m.Content {
+			block := &m.Content[i]
+			switch block.Type {
+			case "text":
+				if text != "" {
+					text += "\n"
+				}
+				text += block.Text
+			case "tool_use":
+				toolUse = block
+			case "tool_result":
+				toolResult = block
+			}
+		}
+
+		switch {
+		case toolResult != nil:
+			out = append(out, openAIChatMessage{Role: "tool", Content: &toolResult.Content, ToolCallID: toolResult.ToolUseID})
+		case toolUse != nil:
+			var contentPtr *string
+			if text != "" {
+				contentPtr = &text
+			}
+			out = append(out, openAIChatMessage{
+				Role:    "assistant",
+				Content: contentPtr,
+				ToolCalls: []openAIToolCall{{
+					ID:   toolUse.ID,
+					Type: "function",
+					Function: openAIFunctionCall{
+						Name:      toolUse.Name,
+						Arguments: string(toolUse.Input),
+					},
+				}},
+			})
+		default:
+			out = append(out, openAIChatMessage{Role: m.Role, Content: &text})
+		}
+	}
+
+	return out
+}
+
+func toOpenAITools(tools []ToolDefinition) []openAIToolDef {
+	defs := make([]openAIToolDef, 0, len(tools))
+	for _, t := range tools {
+		defs = append(defs, openAIToolDef{
+			Type: "function",
+			Function: openAIFunctionDef{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.InputSchema,
+			},
+		})
+	}
+	return defs
+}
+
+// CallLocalLLM sends one turn of the conversation to a self-hosted,
+// OpenAI-compatible chat endpoint and returns the assistant's response in
+// the same generic shape CallClaude produces.
+func CallLocalLLM(baseURL, model, systemPrompt string, messages []Message, tools []ToolDefinition) (*TurnResult, error) {
+	endpoint := strings.TrimRight(baseURL, "/")
+	if !strings.Contains(endpoint, "/chat/completions") {
+		endpoint += "/v1/chat/completions"
+	}
+	// Local inference (especially on CPU, or with a large tool schema) can be slow.
+	return callOpenAICompatible(endpoint, "", nil, model, systemPrompt, messages, tools, 120*time.Second, "local LLM")
+}
+
+// CallOpenRouter sends one turn to OpenRouter's OpenAI-compatible endpoint,
+// which fronts many hosted models (Claude, GPT, Llama, DeepSeek, etc.) behind
+// a single API key.
+func CallOpenRouter(apiKey, model, systemPrompt string, messages []Message, tools []ToolDefinition) (*TurnResult, error) {
+	headers := map[string]string{
+		"HTTP-Referer": "http://localhost:80",
+		"X-Title":      "InfraEye",
+	}
+	return callOpenAICompatible("https://openrouter.ai/api/v1/chat/completions", apiKey, headers, model, systemPrompt, messages, tools, 90*time.Second, "OpenRouter")
+}
+
+// CallMistral sends one turn to Mistral's OpenAI-compatible chat endpoint.
+func CallMistral(apiKey, model, systemPrompt string, messages []Message, tools []ToolDefinition) (*TurnResult, error) {
+	return callOpenAICompatible("https://api.mistral.ai/v1/chat/completions", apiKey, nil, model, systemPrompt, messages, tools, 90*time.Second, "Mistral")
+}
+
+// callOpenAICompatible is the shared client for any provider speaking the
+// OpenAI function-calling wire format (local runtimes, OpenRouter, Mistral).
+// It translates to/from the generic Message/ContentBlock/TurnResult shapes
+// CallClaude uses, so doAgentTurn's orchestration stays provider-agnostic.
+func callOpenAICompatible(endpoint, apiKey string, extraHeaders map[string]string, model, systemPrompt string, messages []Message, tools []ToolDefinition, timeout time.Duration, label string) (*TurnResult, error) {
+	reqBody := localLLMRequest{
+		Model:    model,
+		Messages: toOpenAIMessages(systemPrompt, messages),
+		Tools:    toOpenAITools(tools),
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	for k, v := range extraHeaders {
+		httpReq.Header.Set(k, v)
+	}
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("%s request failed: %w (is the endpoint at %s reachable?)", label, err, endpoint)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var aiResp localLLMResponse
+	if err := json.Unmarshal(body, &aiResp); err != nil {
+		return nil, fmt.Errorf("parse response: %w | raw: %s", err, string(body))
+	}
+	if aiResp.Error != nil {
+		return nil, fmt.Errorf("%s error: %s", label, aiResp.Error.Message)
+	}
+	if len(aiResp.Choices) == 0 {
+		return nil, fmt.Errorf("no response from %s", label)
+	}
+
+	msg := aiResp.Choices[0].Message
+	content := []ContentBlock{}
+	if msg.Content != nil && *msg.Content != "" {
+		content = append(content, ContentBlock{Type: "text", Text: *msg.Content})
+	}
+	stopReason := "end_turn"
+	for _, tc := range msg.ToolCalls {
+		stopReason = "tool_use"
+		content = append(content, ContentBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: json.RawMessage(tc.Function.Arguments),
+		})
+		break // one tool call per turn, matching the agent loop's one-action-per-turn design
+	}
+
+	return &TurnResult{StopReason: stopReason, Content: content}, nil
+}

--- a/backend/internal/handlers/agent.go
+++ b/backend/internal/handlers/agent.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/infra-eye/backend/internal/agent"
+	"github.com/infra-eye/backend/internal/config"
 	"github.com/infra-eye/backend/internal/db"
 	"github.com/infra-eye/backend/internal/models"
 	sshclient "github.com/infra-eye/backend/internal/ssh"
@@ -128,6 +129,79 @@ func buildMessageHistory(run *models.AgentRun, steps []models.AgentStep) []agent
 	return messages
 }
 
+// ── Provider dispatch ────────────────────────────────────────────────────────
+
+// resolveLocalLLM applies the same per-user-override-then-server-default
+// precedent as askAI/askLocalLLM in ai.go.
+func resolveLocalLLM(user models.User) (url, model string) {
+	url = config.C.LocalLLMURL
+	if user.LocalLLMURL != "" {
+		url = user.LocalLLMURL
+	}
+	model = config.C.LocalLLMModel
+	if user.LocalLLMModel != "" {
+		model = user.LocalLLMModel
+	}
+	return url, model
+}
+
+// defaultOpenRouterModel and defaultMistralModel are used when a run's
+// stored Model field is empty (e.g. runs created before per-provider model
+// selection existed).
+const (
+	defaultOpenRouterModel = "openai/gpt-4o-mini"
+	defaultMistralModel    = "mistral-large-latest"
+)
+
+// resolveKey applies the same per-user-override-then-server-default
+// precedent as askAI in ai.go for a plain API key field.
+func resolveKey(userKey, configKey string) string {
+	if userKey != "" {
+		return userKey
+	}
+	return configKey
+}
+
+// callAgentLLM dispatches one tool-calling turn to whichever provider the
+// run was started with.
+func callAgentLLM(run *models.AgentRun, user models.User, systemPrompt string, messages []agent.Message, tools []agent.ToolDefinition) (*agent.TurnResult, error) {
+	model := run.Model
+	switch run.Provider {
+	case "local":
+		url, llmModel := resolveLocalLLM(user)
+		if url == "" {
+			return nil, fmt.Errorf("no local LLM endpoint configured")
+		}
+		if model == "" {
+			model = llmModel
+		}
+		return agent.CallLocalLLM(url, model, systemPrompt, messages, tools)
+	case "openrouter":
+		key := resolveKey(user.OpenRouterKey, config.C.OpenRouterKey)
+		if key == "" {
+			return nil, fmt.Errorf("OpenRouter API key not configured for this user")
+		}
+		if model == "" {
+			model = defaultOpenRouterModel
+		}
+		return agent.CallOpenRouter(key, model, systemPrompt, messages, tools)
+	case "mistral":
+		key := resolveKey(user.MistralKey, config.C.MistralKey)
+		if key == "" {
+			return nil, fmt.Errorf("Mistral API key not configured for this user")
+		}
+		if model == "" {
+			model = defaultMistralModel
+		}
+		return agent.CallMistral(key, model, systemPrompt, messages, tools)
+	default:
+		if user.ClaudeKey == "" {
+			return nil, fmt.Errorf("Claude API key not configured for this user")
+		}
+		return agent.CallClaude(user.ClaudeKey, systemPrompt, messages, tools)
+	}
+}
+
 // ── Turn driver ──────────────────────────────────────────────────────────────
 
 func failAgentRun(run *models.AgentRun, errText string) {
@@ -160,8 +234,8 @@ func doAgentTurn(run *models.AgentRun) {
 	}
 
 	var user models.User
-	if err := db.DB.First(&user, run.UserID).Error; err != nil || user.ClaudeKey == "" {
-		failAgentRun(run, "Claude API key not configured for this user")
+	if err := db.DB.First(&user, run.UserID).Error; err != nil {
+		failAgentRun(run, "user not found")
 		return
 	}
 
@@ -174,7 +248,7 @@ func doAgentTurn(run *models.AgentRun) {
 
 	messages := buildMessageHistory(run, steps)
 
-	result, err := agent.CallClaude(user.ClaudeKey, systemPrompt, messages, tools)
+	result, err := callAgentLLM(run, user, systemPrompt, messages, tools)
 	if err != nil {
 		failAgentRun(run, err.Error())
 		return
@@ -365,9 +439,20 @@ func CreateAgentRun(c *gin.Context) {
 	var req struct {
 		Goal     string `json:"goal" binding:"required"`
 		ServerID uint   `json:"server_id" binding:"required"`
+		Provider string `json:"provider"` // "claude" (default), "local", "openrouter", or "mistral"
+		Model    string `json:"model"`    // optional override; falls back to provider default
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.Provider == "" {
+		req.Provider = "claude"
+	}
+	switch req.Provider {
+	case "claude", "local", "openrouter", "mistral":
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "provider must be one of \"claude\", \"local\", \"openrouter\", \"mistral\""})
 		return
 	}
 
@@ -384,9 +469,42 @@ func CreateAgentRun(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not found"})
 		return
 	}
-	if user.ClaudeKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Set your Claude API key in Settings → AI to use the Agent"})
-		return
+
+	model := req.Model
+	switch req.Provider {
+	case "claude":
+		if user.ClaudeKey == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Set your Claude API key in Settings → AI to use the Agent"})
+			return
+		}
+		if model == "" {
+			model = agent.ClaudeModel
+		}
+	case "local":
+		url, localModel := resolveLocalLLM(user)
+		if url == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "No local LLM endpoint configured. Set LOCAL_LLM_URL (server-wide) or add your local endpoint in Settings → AI."})
+			return
+		}
+		if model == "" {
+			model = localModel
+		}
+	case "openrouter":
+		if resolveKey(user.OpenRouterKey, config.C.OpenRouterKey) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Set your OpenRouter API key in Settings → AI to use the Agent"})
+			return
+		}
+		if model == "" {
+			model = defaultOpenRouterModel
+		}
+	case "mistral":
+		if resolveKey(user.MistralKey, config.C.MistralKey) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Set your Mistral API key in Settings → AI to use the Agent"})
+			return
+		}
+		if model == "" {
+			model = defaultMistralModel
+		}
 	}
 
 	if err := db.DB.First(&models.Server{}, req.ServerID).Error; err != nil {
@@ -399,8 +517,8 @@ func CreateAgentRun(c *gin.Context) {
 		ServerID:  req.ServerID,
 		Goal:      req.Goal,
 		Status:    "running",
-		Provider:  "claude",
-		Model:     agent.ClaudeModel,
+		Provider:  req.Provider,
+		Model:     model,
 		StartedAt: time.Now(),
 	}
 	if err := db.DB.Create(&run).Error; err != nil {
@@ -527,6 +645,19 @@ func CancelAgentRun(c *gin.Context) {
 	ws.GlobalHub.Broadcast(agentRoom(run.ID), "run_cancelled", gin.H{"run_id": run.ID, "status": run.Status})
 
 	c.JSON(http.StatusOK, loadAgentRunWithSteps(run.ID))
+}
+
+// DeleteAgentRun — DELETE /api/agent/runs/:id
+func DeleteAgentRun(c *gin.Context) {
+	run, ok := loadOwnedAgentRun(c)
+	if !ok {
+		return
+	}
+
+	db.DB.Where("agent_run_id = ?", run.ID).Delete(&models.AgentStep{})
+	db.DB.Delete(&run)
+
+	c.JSON(http.StatusOK, gin.H{"id": run.ID})
 }
 
 // AgentRunWS subscribes a client to live updates for one agent run.

--- a/backend/internal/handlers/agent.go
+++ b/backend/internal/handlers/agent.go
@@ -354,7 +354,7 @@ func loadOwnedAgentRun(c *gin.Context) (models.AgentRun, bool) {
 func loadAgentRunWithSteps(runID uint) models.AgentRun {
 	var run models.AgentRun
 	db.DB.First(&run, runID)
-	var steps []models.AgentStep
+	steps := []models.AgentStep{}
 	db.DB.Where("agent_run_id = ?", runID).Order("step_number ASC").Find(&steps)
 	run.Steps = steps
 	return run
@@ -416,7 +416,7 @@ func CreateAgentRun(c *gin.Context) {
 // ListAgentRuns — GET /api/agent/runs
 func ListAgentRuns(c *gin.Context) {
 	userID := c.GetUint("user_id")
-	var runs []models.AgentRun
+	runs := []models.AgentRun{}
 	db.DB.Where("user_id = ?", userID).Order("created_at DESC").Find(&runs)
 	c.JSON(http.StatusOK, runs)
 }

--- a/backend/internal/httpapi/routes.go
+++ b/backend/internal/httpapi/routes.go
@@ -143,6 +143,7 @@ func RegisterRoutes(r *gin.Engine) {
 		api.POST("/agent/runs/:id/steps/:stepId/approve", middleware.RequireRole("admin", "devops"), handlers.ApproveAgentStep)
 		api.POST("/agent/runs/:id/steps/:stepId/reject", middleware.RequireRole("admin", "devops"), handlers.RejectAgentStep)
 		api.POST("/agent/runs/:id/cancel", middleware.RequireRole("admin", "devops"), handlers.CancelAgentRun)
+		api.DELETE("/agent/runs/:id", middleware.RequireRole("admin", "devops"), handlers.DeleteAgentRun)
 
 		// ── Alert rules ───────────────────────────────────────────
 		api.GET("/alert-rules", middleware.RequireRole("admin", "devops", "trainee"), handlers.ListAlertRules)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -272,7 +272,7 @@ type AgentRun struct {
 	StartedAt  time.Time   `json:"started_at"`
 	FinishedAt *time.Time  `json:"finished_at"`
 	ErrorText  string      `gorm:"type:text" json:"error_text"`
-	Steps      []AgentStep `gorm:"foreignKey:AgentRunID" json:"steps,omitempty"`
+	Steps      []AgentStep `gorm:"foreignKey:AgentRunID" json:"steps"`
 	CreatedAt  time.Time   `gorm:"index" json:"created_at"`
 	UpdatedAt  time.Time   `json:"updated_at"`
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "@xyflow/react": "^12.11.3",
         "axios": "^1.19.0",
         "date-fns": "^4.1.0",
         "devicon": "^2.17.0",
@@ -723,9 +724,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -743,9 +741,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -763,9 +758,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -783,9 +775,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -803,9 +792,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -823,9 +809,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -917,6 +900,15 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
@@ -947,6 +939,12 @@
         "@types/d3-time": "*"
       }
     },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
@@ -967,6 +965,25 @@
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -1065,7 +1082,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -1471,6 +1488,76 @@
         "addons/*"
       ]
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.3",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.3.tgz",
+      "integrity": "sha512-G3jogHz2GWUtIOkhavUGno2YzY9u6fILIJBttfsBendb0/HWB90JG+sOTAvlIMEwyvq9zgy9V9ZQSwyQjR5QzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.80",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.80",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.80.tgz",
+      "integrity": "sha512-ywc3ZqG91brzWrH1WlwMdIX4goOfrpBy6AbLdVSaof/Xx9l138ijIKRExM6EkMro2F+OImGmSiA/WKcXvKVcfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1749,6 +1836,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1869,6 +1962,28 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -1924,6 +2039,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
@@ -1965,6 +2089,41 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -3255,9 +3414,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3279,9 +3435,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3303,9 +3456,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3327,9 +3477,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "@xyflow/react": "^12.11.3",
     "axios": "^1.19.0",
     "date-fns": "^4.1.0",
     "devicon": "^2.17.0",

--- a/frontend/src/components/agent/AgentFlowCanvas.tsx
+++ b/frontend/src/components/agent/AgentFlowCanvas.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useMemo } from 'react'
+import {
+  ReactFlow, ReactFlowProvider, Background, Controls, BackgroundVariant,
+  useReactFlow, type Node, type Edge, type NodeTypes,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import { GoalFlowNode, StepFlowNode, ThinkingFlowNode, nodeColor } from './AgentFlowNodes'
+import type { AgentRun } from '../../pages/agentTypes'
+
+const nodeTypes: NodeTypes = {
+  goal: GoalFlowNode,
+  step: StepFlowNode,
+  thinking: ThinkingFlowNode,
+}
+
+const NODE_SPACING = 260
+
+interface AgentFlowCanvasProps {
+  run: AgentRun
+  selectedStepId: number | null
+  onSelectStep: (id: number | null) => void
+  onApprove: (id: number) => void
+  onReject: (id: number) => void
+  busyStepId: number | null
+}
+
+function FlowInner({ run, selectedStepId, onSelectStep, onApprove, onReject, busyStepId }: AgentFlowCanvasProps) {
+  const { fitView } = useReactFlow()
+  const isRunning = run.status === 'running'
+  const steps = run.steps ?? []
+
+  const { nodes, edges } = useMemo(() => {
+    const nodes: Node[] = [
+      {
+        id: 'goal',
+        type: 'goal',
+        position: { x: 0, y: 60 },
+        data: { kind: 'goal', goal: run.goal, selected: false },
+        draggable: false,
+        selectable: false,
+      },
+    ]
+    const edges: Edge[] = []
+    let prevId = 'goal'
+    let prevColor = 'var(--brand-primary)'
+
+    steps.forEach((step, i) => {
+      const id = `step-${step.id}`
+      const color = nodeColor(step)
+      nodes.push({
+        id,
+        type: 'step',
+        position: { x: (i + 1) * NODE_SPACING, y: 60 },
+        data: { kind: 'step', step, selected: selectedStepId === step.id, isBusy: busyStepId === step.id, onApprove, onReject },
+        draggable: false,
+      })
+      edges.push({
+        id: `e-${prevId}-${id}`,
+        source: prevId,
+        target: id,
+        type: 'smoothstep',
+        animated: step.status === 'pending_approval',
+        style: { stroke: prevColor === 'var(--brand-primary)' ? 'var(--border)' : prevColor, strokeWidth: 2 },
+      })
+      prevId = id
+      prevColor = color
+    })
+
+    if (isRunning) {
+      const id = 'thinking'
+      nodes.push({
+        id,
+        type: 'thinking',
+        position: { x: (steps.length + 1) * NODE_SPACING, y: 66 },
+        data: { kind: 'thinking' },
+        draggable: false,
+        selectable: false,
+      })
+      edges.push({
+        id: `e-${prevId}-${id}`,
+        source: prevId,
+        target: id,
+        type: 'smoothstep',
+        animated: true,
+        style: { stroke: 'var(--brand-primary)', strokeWidth: 2, strokeDasharray: '4 3' },
+      })
+    }
+
+    return { nodes, edges }
+  }, [run.goal, steps, isRunning, selectedStepId, busyStepId, onApprove, onReject])
+
+  useEffect(() => {
+    fitView({ padding: 0.25, duration: 400, maxZoom: 1 })
+  }, [nodes.length, fitView])
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      onNodeClick={(_, node) => {
+        if (node.type === 'step') onSelectStep(Number(node.id.replace('step-', '')))
+      }}
+      onPaneClick={() => onSelectStep(null)}
+      proOptions={{ hideAttribution: true }}
+      minZoom={0.3}
+      maxZoom={1.5}
+      panOnScroll
+      fitView
+    >
+      <Background variant={BackgroundVariant.Dots} gap={22} size={1.4} color="var(--border)" />
+      <Controls showInteractive={false} position="bottom-right" />
+    </ReactFlow>
+  )
+}
+
+export function AgentFlowCanvas(props: AgentFlowCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <FlowInner {...props} />
+    </ReactFlowProvider>
+  )
+}

--- a/frontend/src/components/agent/AgentFlowNodes.tsx
+++ b/frontend/src/components/agent/AgentFlowNodes.tsx
@@ -1,0 +1,169 @@
+import { memo } from 'react'
+import { Handle, Position } from '@xyflow/react'
+import {
+  Target, Terminal, Boxes, Flag, CheckCircle2, XCircle,
+  AlertTriangle, Ban, Loader, Clock, Check, X,
+} from 'lucide-react'
+import type { AgentStep } from '../../pages/agentTypes'
+
+export function kindMeta(kind: AgentStep['kind']) {
+  switch (kind) {
+    case 'ssh_command': return { label: 'SSH command', icon: Terminal, color: 'var(--info, #3b82f6)' }
+    case 'mcp_tool': return { label: 'Kubernetes / MCP', icon: Boxes, color: 'var(--brand-primary)' }
+    case 'unknown_tool': return { label: 'Unknown tool', icon: Ban, color: 'var(--danger)' }
+    default: return { label: 'Final answer', icon: Flag, color: 'var(--success)' }
+  }
+}
+
+export function nodeColor(step: AgentStep): string {
+  if (step.kind === 'final_answer') return 'var(--success)'
+  switch (step.status) {
+    case 'pending_approval': return 'var(--warning, #d97706)'
+    case 'executed': return 'var(--success)'
+    case 'failed': return 'var(--danger)'
+    case 'rejected': return 'var(--text-muted)'
+    default: return kindMeta(step.kind).color
+  }
+}
+
+export interface GoalNodeData extends Record<string, unknown> {
+  kind: 'goal'
+  goal: string
+  selected: boolean
+}
+
+export interface StepNodeData extends Record<string, unknown> {
+  kind: 'step'
+  step: AgentStep
+  selected: boolean
+  isBusy: boolean
+  onApprove: (id: number) => void
+  onReject: (id: number) => void
+}
+
+export interface ThinkingNodeData extends Record<string, unknown> {
+  kind: 'thinking'
+}
+
+export const GoalFlowNode = memo(({ data }: { data: GoalNodeData }) => (
+  <div
+    style={{
+      width: 220, borderRadius: 999, padding: '12px 18px',
+      background: 'var(--brand-primary)', color: 'var(--text-inverse)',
+      display: 'flex', alignItems: 'center', gap: 10,
+      boxShadow: data.selected ? '0 0 0 3px var(--brand-glow)' : '0 1px 3px rgba(0,0,0,0.15)',
+      cursor: 'default',
+    }}
+  >
+    <Target size={16} strokeWidth={2.4} style={{ flexShrink: 0 }} />
+    <div style={{ minWidth: 0 }}>
+      <div style={{ fontSize: 9.5, fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.08em', opacity: 0.85 }}>Goal</div>
+      <div style={{ fontSize: 12.5, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{data.goal}</div>
+    </div>
+    <Handle type="source" position={Position.Right} style={{ background: 'var(--brand-primary)', border: 'none', width: 8, height: 8 }} />
+  </div>
+))
+GoalFlowNode.displayName = 'GoalFlowNode'
+
+export const StepFlowNode = memo(({ data }: { data: StepNodeData }) => {
+  const { step, selected, isBusy, onApprove, onReject } = data
+  const color = nodeColor(step)
+  const meta = kindMeta(step.kind)
+  const isFinal = step.kind === 'final_answer'
+  const Icon = step.status === 'failed' ? AlertTriangle
+    : step.status === 'rejected' ? XCircle
+    : isFinal ? Flag
+    : step.status === 'executed' ? CheckCircle2
+    : step.status === 'pending_approval' ? Clock
+    : meta.icon
+
+  return (
+    <div
+      style={{
+        width: 230, borderRadius: 'var(--radius-lg)', background: 'var(--bg-card)',
+        border: `1.5px solid ${selected ? color : 'var(--border)'}`,
+        boxShadow: selected ? `0 0 0 3px color-mix(in srgb, ${color} 22%, transparent)` : '0 1px 3px rgba(0,0,0,0.1)',
+        overflow: 'hidden', cursor: 'pointer', position: 'relative',
+      }}
+    >
+      <Handle type="target" position={Position.Left} style={{ background: color, border: 'none', width: 8, height: 8 }} />
+      {step.status === 'pending_approval' && (
+        <span style={{
+          position: 'absolute', top: 8, right: 8, width: 8, height: 8, borderRadius: '50%',
+          background: color, boxShadow: `0 0 0 4px color-mix(in srgb, ${color} 25%, transparent)`,
+        }} className="agent-node-pulse" />
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', borderBottom: '1px solid var(--border)', background: 'var(--bg-elevated)' }}>
+        <div style={{
+          width: 24, height: 24, borderRadius: 7, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'var(--bg-card)', border: `1.5px solid ${color}`, color,
+        }}>
+          <Icon size={12.5} strokeWidth={2.6} />
+        </div>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontSize: 9.5, fontWeight: 800, color: 'var(--text-muted)', letterSpacing: '0.04em' }}>STEP {step.step_number}</div>
+          <div style={{ fontSize: 12, fontWeight: 800, color, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{meta.label}</div>
+        </div>
+      </div>
+      <div style={{ padding: '9px 12px' }}>
+        {step.tool_name ? (
+          <code style={{ fontSize: 11, color: 'var(--text-secondary)', background: 'var(--bg-elevated)', padding: '3px 7px', borderRadius: 6, display: 'inline-block', maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {step.tool_name}
+          </code>
+        ) : (
+          <div style={{ fontSize: 11.5, color: 'var(--text-muted)', fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {(step.reasoning || '').slice(0, 60) || 'Mission complete'}
+          </div>
+        )}
+      </div>
+      {step.status === 'pending_approval' && (
+        <div
+          className="nodrag"
+          style={{ display: 'flex', gap: 6, padding: '0 10px 10px' }}
+          onClick={e => e.stopPropagation()}
+        >
+          <button
+            disabled={isBusy}
+            onClick={() => onApprove(step.id)}
+            title="Approve & run"
+            style={{
+              flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5, padding: '6px 8px', borderRadius: 7,
+              background: 'var(--brand-primary)', color: 'var(--text-inverse)', border: 'none', fontSize: 11, fontWeight: 800,
+              cursor: isBusy ? 'default' : 'pointer', opacity: isBusy ? 0.6 : 1,
+            }}
+          >
+            {isBusy ? <Loader size={11} className="spin" /> : <Check size={11} strokeWidth={3} />}
+            Approve
+          </button>
+          <button
+            disabled={isBusy}
+            onClick={() => onReject(step.id)}
+            title="Reject"
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '6px 9px', borderRadius: 7,
+              background: 'var(--bg-elevated)', color: 'var(--text-secondary)', border: '1px solid var(--border)',
+              cursor: isBusy ? 'default' : 'pointer', opacity: isBusy ? 0.6 : 1,
+            }}
+          >
+            <X size={11} strokeWidth={3} />
+          </button>
+        </div>
+      )}
+      <Handle type="source" position={Position.Right} style={{ background: color, border: 'none', width: 8, height: 8 }} />
+    </div>
+  )
+})
+StepFlowNode.displayName = 'StepFlowNode'
+
+export const ThinkingFlowNode = memo(() => (
+  <div style={{
+    width: 190, borderRadius: 'var(--radius-lg)', padding: '12px 14px',
+    background: 'var(--bg-card)', border: '1.5px dashed var(--brand-primary)',
+    display: 'flex', alignItems: 'center', gap: 9,
+  }}>
+    <Handle type="target" position={Position.Left} style={{ background: 'var(--brand-primary)', border: 'none', width: 8, height: 8 }} />
+    <Loader size={14} className="spin" color="var(--brand-primary)" />
+    <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--brand-primary)' }}>Deciding next step…</span>
+  </div>
+))
+ThinkingFlowNode.displayName = 'ThinkingFlowNode'

--- a/frontend/src/components/agent/LauncherFlowCanvas.tsx
+++ b/frontend/src/components/agent/LauncherFlowCanvas.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useMemo } from 'react'
+import {
+  ReactFlow, ReactFlowProvider, Background, Controls, BackgroundVariant,
+  useReactFlow, type Node, type Edge, type NodeTypes,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import {
+  ServerConfigNode, ProviderConfigNode, GoalConfigNode, TriggerConfigNode, type AgentProvider,
+} from './LauncherFlowNodes'
+import type { ServerData } from '../../pages/agentTypes'
+
+const nodeTypes: NodeTypes = {
+  serverConfig: ServerConfigNode,
+  providerConfig: ProviderConfigNode,
+  goalConfig: GoalConfigNode,
+  trigger: TriggerConfigNode,
+}
+
+interface LauncherFlowCanvasProps {
+  servers: ServerData[]
+  selectedServer: number | ''
+  onSelectServer: (id: number | '') => void
+  provider: AgentProvider
+  onSelectProvider: (p: AgentProvider) => void
+  goal: string
+  onGoalChange: (goal: string) => void
+  onLaunch: () => void
+  isLaunchable: boolean
+  starting: boolean
+}
+
+function FlowInner(props: LauncherFlowCanvasProps) {
+  const { fitView } = useReactFlow()
+  const {
+    servers, selectedServer, onSelectServer, provider, onSelectProvider,
+    goal, onGoalChange, onLaunch, isLaunchable, starting,
+  } = props
+
+  const { nodes, edges } = useMemo(() => {
+    const nodes: Node[] = [
+      {
+        id: 'server', type: 'serverConfig', position: { x: 0, y: 40 },
+        data: { servers, selectedServer, onChange: onSelectServer },
+        draggable: false,
+      },
+      {
+        id: 'provider', type: 'providerConfig', position: { x: 280, y: 40 },
+        data: { provider, onChange: onSelectProvider },
+        draggable: false,
+      },
+      {
+        id: 'goal', type: 'goalConfig', position: { x: 560, y: 0 },
+        data: { goal, onChange: onGoalChange, disabled: starting },
+        draggable: false,
+      },
+      {
+        id: 'trigger', type: 'trigger', position: { x: 920, y: 30 },
+        data: { isLaunchable, starting, onLaunch },
+        draggable: false,
+      },
+    ]
+    const edges: Edge[] = [
+      { id: 'e-server-provider', source: 'server', target: 'provider', type: 'smoothstep', style: { stroke: 'var(--border)', strokeWidth: 2 } },
+      { id: 'e-provider-goal', source: 'provider', target: 'goal', type: 'smoothstep', style: { stroke: 'var(--border)', strokeWidth: 2 } },
+      { id: 'e-goal-trigger', source: 'goal', target: 'trigger', type: 'smoothstep', animated: isLaunchable, style: { stroke: isLaunchable ? 'var(--brand-primary)' : 'var(--border)', strokeWidth: 2 } },
+    ]
+    return { nodes, edges }
+  }, [servers, selectedServer, onSelectServer, provider, onSelectProvider, goal, onGoalChange, onLaunch, isLaunchable, starting])
+
+  useEffect(() => {
+    fitView({ padding: 0.3, duration: 300, maxZoom: 1 })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fitView])
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      proOptions={{ hideAttribution: true }}
+      minZoom={0.4}
+      maxZoom={1.5}
+      panOnScroll
+      nodesDraggable={false}
+      fitView
+    >
+      <Background variant={BackgroundVariant.Dots} gap={22} size={1.4} color="var(--border)" />
+      <Controls showInteractive={false} position="bottom-right" />
+    </ReactFlow>
+  )
+}
+
+export function LauncherFlowCanvas(props: LauncherFlowCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <FlowInner {...props} />
+    </ReactFlowProvider>
+  )
+}

--- a/frontend/src/components/agent/LauncherFlowNodes.tsx
+++ b/frontend/src/components/agent/LauncherFlowNodes.tsx
@@ -1,0 +1,139 @@
+import { memo } from 'react'
+import { Handle, Position } from '@xyflow/react'
+import { ChevronDown, Server, Cpu, Target, Rocket, Loader } from 'lucide-react'
+import type { ServerData } from '../../pages/agentTypes'
+
+export type AgentProvider = 'claude' | 'local' | 'openrouter' | 'mistral'
+
+const PROVIDER_OPTIONS: { value: AgentProvider; label: string }[] = [
+  { value: 'claude', label: 'Claude (requires API key)' },
+  { value: 'openrouter', label: 'OpenRouter (requires API key)' },
+  { value: 'mistral', label: 'Mistral (requires API key)' },
+  { value: 'local', label: 'Local LLM (self-hosted, no API key)' },
+]
+
+const selectStyle: React.CSSProperties = {
+  height: 34, padding: '0 26px 0 10px', borderRadius: 'var(--radius-md)',
+  background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+  color: 'var(--text-primary)', fontSize: 12.5, fontWeight: 700,
+  cursor: 'pointer', outline: 'none', appearance: 'none', WebkitAppearance: 'none', width: '100%',
+}
+
+function ConfigCard({ icon: Icon, label, children, width = 240 }: { icon: React.ElementType; label: string; children: React.ReactNode; width?: number }) {
+  return (
+    <div style={{
+      width, borderRadius: 'var(--radius-lg)', background: 'var(--bg-card)',
+      border: '1.5px solid var(--border)', boxShadow: '0 1px 3px rgba(0,0,0,0.1)', overflow: 'hidden',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '9px 12px', borderBottom: '1px solid var(--border)', background: 'var(--bg-elevated)' }}>
+        <Icon size={13} color="var(--brand-primary)" strokeWidth={2.4} />
+        <span style={{ fontSize: 10.5, fontWeight: 800, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{label}</span>
+      </div>
+      <div className="nodrag nopan" style={{ padding: '10px 12px' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export interface ServerNodeData extends Record<string, unknown> {
+  servers: ServerData[]
+  selectedServer: number | ''
+  onChange: (id: number | '') => void
+}
+
+export const ServerConfigNode = memo(({ data }: { data: ServerNodeData }) => (
+  <ConfigCard icon={Server} label="Target server">
+    <div style={{ position: 'relative' }}>
+      <select value={data.selectedServer} onChange={e => data.onChange(Number(e.target.value) || '')} style={selectStyle}>
+        <option value="">Select a server…</option>
+        {data.servers.map(s => <option key={s.id} value={s.id}>{s.is_k8s ? '☸ ' : ''}{s.name}</option>)}
+      </select>
+      <ChevronDown size={12} color="var(--text-muted)" style={{ position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }} />
+    </div>
+    <Handle type="source" position={Position.Right} style={{ background: 'var(--border)', border: 'none', width: 8, height: 8 }} />
+  </ConfigCard>
+))
+ServerConfigNode.displayName = 'ServerConfigNode'
+
+export interface ProviderNodeData extends Record<string, unknown> {
+  provider: AgentProvider
+  onChange: (p: AgentProvider) => void
+}
+
+export const ProviderConfigNode = memo(({ data }: { data: ProviderNodeData }) => (
+  <ConfigCard icon={Cpu} label="Model provider">
+    <div style={{ position: 'relative' }}>
+      <select value={data.provider} onChange={e => data.onChange(e.target.value as AgentProvider)} style={selectStyle}>
+        {PROVIDER_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+      </select>
+      <ChevronDown size={12} color="var(--text-muted)" style={{ position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }} />
+    </div>
+    <Handle type="target" position={Position.Left} style={{ background: 'var(--border)', border: 'none', width: 8, height: 8 }} />
+    <Handle type="source" position={Position.Right} style={{ background: 'var(--border)', border: 'none', width: 8, height: 8 }} />
+  </ConfigCard>
+))
+ProviderConfigNode.displayName = 'ProviderConfigNode'
+
+export interface GoalNodeData extends Record<string, unknown> {
+  goal: string
+  onChange: (goal: string) => void
+  disabled: boolean
+}
+
+export const GoalConfigNode = memo(({ data }: { data: GoalNodeData }) => (
+  <ConfigCard icon={Target} label="Goal" width={300}>
+    <textarea
+      value={data.goal}
+      onChange={e => data.onChange(e.target.value)}
+      placeholder='e.g. "restart the nginx service" or "scale the checkout deployment to 3 replicas"'
+      rows={4}
+      disabled={data.disabled}
+      className="nowheel"
+      style={{
+        width: '100%', background: 'var(--bg-input)', border: '1px solid var(--border)', borderRadius: 'var(--radius-md)',
+        color: 'var(--text-primary)', fontSize: 12.5, padding: '8px 10px', resize: 'vertical', lineHeight: 1.6, outline: 'none',
+        fontFamily: 'inherit', boxSizing: 'border-box',
+      }}
+    />
+    <Handle type="target" position={Position.Left} style={{ background: 'var(--border)', border: 'none', width: 8, height: 8 }} />
+    <Handle type="source" position={Position.Right} style={{ background: 'var(--border)', border: 'none', width: 8, height: 8 }} />
+  </ConfigCard>
+))
+GoalConfigNode.displayName = 'GoalConfigNode'
+
+export interface TriggerNodeData extends Record<string, unknown> {
+  isLaunchable: boolean
+  starting: boolean
+  onLaunch: () => void
+}
+
+export const TriggerConfigNode = memo(({ data }: { data: TriggerNodeData }) => (
+  <div
+    className="nodrag nopan"
+    style={{
+      width: 190, borderRadius: 'var(--radius-lg)', padding: '14px 16px',
+      background: data.isLaunchable ? 'var(--brand-glow)' : 'var(--bg-card)',
+      border: `1.5px solid ${data.isLaunchable ? 'var(--brand-primary)' : 'var(--border)'}`,
+      display: 'flex', flexDirection: 'column', gap: 8, position: 'relative',
+    }}
+  >
+    <Handle type="target" position={Position.Left} style={{ background: 'var(--border)', border: 'none', width: 8, height: 8 }} />
+    <span style={{ fontSize: 10.5, fontWeight: 800, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Trigger</span>
+    <button
+      onClick={data.onLaunch}
+      disabled={!data.isLaunchable}
+      style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+        height: 36, borderRadius: 'var(--radius-md)', border: 'none', fontSize: 13, fontWeight: 800,
+        background: data.isLaunchable ? 'var(--brand-primary)' : 'var(--bg-elevated)',
+        color: data.isLaunchable ? 'var(--text-inverse)' : 'var(--text-muted)',
+        cursor: data.isLaunchable ? 'pointer' : 'default',
+      }}
+    >
+      {data.starting ? <Loader size={14} className="spin" /> : <Rocket size={14} />}
+      {data.starting ? 'Launching…' : 'Launch Agent'}
+    </button>
+  </div>
+))
+TriggerConfigNode.displayName = 'TriggerConfigNode'

--- a/frontend/src/components/agent/RunSidebar.tsx
+++ b/frontend/src/components/agent/RunSidebar.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useEffect, useCallback } from 'react'
-import { X, ChevronLeft, ChevronRight, Plus, Workflow } from 'lucide-react'
+import { X, ChevronLeft, ChevronRight, Plus, Workflow, Trash2 } from 'lucide-react'
 
 export interface AgentRunSummary {
   id: number
@@ -13,6 +13,7 @@ interface RunSidebarProps {
   activeRunId: number | null
   onSelect: (id: number) => void
   onNew: () => void
+  onDelete: (id: number) => void
   isCollapsed: boolean
   onToggle: (v: boolean) => void
 }
@@ -47,10 +48,11 @@ const STATUS_LABEL: Record<AgentRunSummary['status'], string> = {
 }
 
 export const RunSidebar = memo(({
-  runs, activeRunId, onSelect, onNew, isCollapsed, onToggle,
+  runs, activeRunId, onSelect, onNew, onDelete, isCollapsed, onToggle,
 }: RunSidebarProps) => {
   const [width, setWidth] = useState(280)
   const [isResizing, setIsResizing] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState<number | null>(null)
 
   const startResizing = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
@@ -197,20 +199,49 @@ export const RunSidebar = memo(({
             onMouseLeave={e => { if (activeRunId !== r.id) e.currentTarget.style.background = 'transparent' }}
           >
             {!isCollapsed ? (
-              <div style={{ minWidth: 0, flex: 1 }}>
-                <div style={{
-                  fontSize: 13.5, color: activeRunId === r.id ? 'var(--text-primary)' : 'var(--text-secondary)',
-                  fontWeight: activeRunId === r.id ? 700 : 600,
-                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-                }}>
-                  {r.goal}
+              <>
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div style={{
+                    fontSize: 13.5, color: activeRunId === r.id ? 'var(--text-primary)' : 'var(--text-secondary)',
+                    fontWeight: activeRunId === r.id ? 700 : 600,
+                    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                  }}>
+                    {r.goal}
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3 }}>
+                    <span style={{ width: 6, height: 6, borderRadius: '50%', background: STATUS_COLOR[r.status], flexShrink: 0 }} />
+                    <span style={{ fontSize: 11.5, color: STATUS_COLOR[r.status], fontWeight: 700 }}>{STATUS_LABEL[r.status]}</span>
+                    <span style={{ fontSize: 11.5, color: 'var(--text-muted)', fontWeight: 600 }}>· {timeAgo(r.created_at)}</span>
+                  </div>
                 </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3 }}>
-                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: STATUS_COLOR[r.status], flexShrink: 0 }} />
-                  <span style={{ fontSize: 11.5, color: STATUS_COLOR[r.status], fontWeight: 700 }}>{STATUS_LABEL[r.status]}</span>
-                  <span style={{ fontSize: 11.5, color: 'var(--text-muted)', fontWeight: 600 }}>· {timeAgo(r.created_at)}</span>
-                </div>
-              </div>
+                {confirmDelete === r.id ? (
+                  <div style={{ display: 'flex', gap: 4, flexShrink: 0 }} onClick={e => e.stopPropagation()}>
+                    <button
+                      title="Confirm delete"
+                      onClick={() => { onDelete(r.id); setConfirmDelete(null) }}
+                      style={{ padding: '4px 8px', borderRadius: 'var(--radius-md)', fontSize: 11, background: 'var(--danger)', border: 'none', color: '#fff', cursor: 'pointer', fontWeight: 800 }}
+                    >
+                      Delete
+                    </button>
+                    <button
+                      title="Cancel"
+                      onClick={() => setConfirmDelete(null)}
+                      style={{ padding: '4px 8px', borderRadius: 'var(--radius-md)', fontSize: 11, background: 'var(--bg-elevated)', border: '1px solid var(--border)', color: 'var(--text-muted)', cursor: 'pointer', fontWeight: 700 }}
+                    >
+                      Keep
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    className="btn-icon danger"
+                    title="Delete run"
+                    onClick={e => { e.stopPropagation(); setConfirmDelete(r.id) }}
+                    style={{ width: 26, height: 26, flexShrink: 0 }}
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                )}
+              </>
             ) : (
               <div style={{ width: 8, height: 8, borderRadius: '50%', background: STATUS_COLOR[r.status] }} />
             )}

--- a/frontend/src/components/agent/StepInspector.tsx
+++ b/frontend/src/components/agent/StepInspector.tsx
@@ -1,0 +1,132 @@
+import Markdown, { type Components } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { X } from 'lucide-react'
+import { Badge } from '../ui'
+import { kindMeta, nodeColor } from './AgentFlowNodes'
+import type { AgentStep } from '../../pages/agentTypes'
+
+function prettyArgs(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2)
+  } catch {
+    return raw
+  }
+}
+
+const markdownComponents: Components = {
+  p: ({ children }) => <p style={{ margin: '0 0 10px' }}>{children}</p>,
+  ul: ({ children }) => <ul style={{ margin: '0 0 10px', paddingLeft: 20, listStyleType: 'disc', color: 'var(--text-secondary)' }}>{children}</ul>,
+  ol: ({ children }) => <ol style={{ margin: '0 0 10px', paddingLeft: 20, listStyleType: 'decimal', color: 'var(--text-secondary)' }}>{children}</ol>,
+  li: ({ children }) => <li style={{ marginBottom: 5, lineHeight: 1.6, paddingLeft: 2 }}>{children}</li>,
+  h1: ({ children }) => <h1 style={{ fontSize: 15, fontWeight: 800, margin: '16px 0 8px', color: 'var(--text-primary)' }}>{children}</h1>,
+  h2: ({ children }) => <h2 style={{ fontSize: 14, fontWeight: 800, margin: '16px 0 8px', color: 'var(--text-primary)' }}>{children}</h2>,
+  h3: ({ children }) => <h3 style={{ fontSize: 13, fontWeight: 700, margin: '14px 0 6px', color: 'var(--text-primary)' }}>{children}</h3>,
+  h4: ({ children }) => <h4 style={{ fontSize: 12.5, fontWeight: 700, margin: '12px 0 6px', color: 'var(--text-primary)' }}>{children}</h4>,
+  hr: () => <hr style={{ border: 'none', borderTop: '1px solid var(--border)', margin: '14px 0' }} />,
+  a: ({ href, children }) => <a href={href} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--brand-primary)', textDecoration: 'none', fontWeight: 600 }}>{children}</a>,
+  blockquote: ({ children }) => <blockquote style={{ borderLeft: '3px solid var(--brand-primary)', margin: '10px 0', color: 'var(--text-secondary)', background: 'var(--bg-elevated)', padding: '8px 12px', borderRadius: '0 var(--radius-md) var(--radius-md) 0' }}>{children}</blockquote>,
+  strong: ({ children }) => <strong style={{ fontWeight: 700, color: 'var(--text-primary)' }}>{children}</strong>,
+  code: ({ children, className }) => {
+    const isInline = !className
+    return isInline ? (
+      <code style={{
+        background: 'var(--bg-elevated)', padding: '2px 6px', borderRadius: 4,
+        fontFamily: 'var(--font-mono, monospace)', fontSize: 12, color: 'var(--text-primary)',
+        fontWeight: 700, border: '1px solid var(--border)', overflowWrap: 'anywhere',
+      }}>{children}</code>
+    ) : (
+      <code style={{ fontFamily: 'var(--font-mono, monospace)' }}>{children}</code>
+    )
+  },
+  pre: ({ children }) => (
+    <pre style={{
+      margin: '0 0 10px', padding: '10px 12px', background: 'var(--bg-elevated)',
+      borderRadius: 'var(--radius-md)', overflowX: 'auto', fontSize: 11.5,
+      fontFamily: 'var(--font-mono, monospace)', border: '1px solid var(--border)',
+    }}>{children}</pre>
+  ),
+  table: ({ children }) => (
+    <div style={{ overflowX: 'auto', margin: '0 0 10px', borderRadius: 'var(--radius-md)', border: '1px solid var(--border)' }}>
+      <table style={{ margin: 0, borderCollapse: 'collapse', width: '100%' }}>{children}</table>
+    </div>
+  ),
+  th: ({ children }) => <th style={{ padding: '8px 10px', textAlign: 'left', borderBottom: '2px solid var(--border)', fontSize: 11, textTransform: 'uppercase', color: 'var(--text-muted)', letterSpacing: '0.05em', whiteSpace: 'nowrap' }}>{children}</th>,
+  td: ({ children }) => <td style={{ padding: '7px 10px', borderBottom: '1px solid var(--border)', fontSize: 12, color: 'var(--text-secondary)', verticalAlign: 'top' }}>{children}</td>,
+}
+
+interface StepInspectorProps {
+  step: AgentStep
+  onClose: () => void
+}
+
+export function StepInspector({ step, onClose }: StepInspectorProps) {
+  const color = nodeColor(step)
+  const meta = kindMeta(step.kind)
+  const isFinal = step.kind === 'final_answer'
+
+  return (
+    <div
+      className="fade-up"
+      style={{
+        position: 'absolute', top: 14, right: 14, bottom: 14, width: 380, maxWidth: 'calc(100% - 28px)',
+        background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)',
+        boxShadow: '0 8px 28px rgba(0,0,0,0.18)', display: 'flex', flexDirection: 'column', overflow: 'hidden', zIndex: 20,
+      }}
+    >
+      <div style={{ padding: '14px 16px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontSize: 10.5, fontWeight: 800, color: 'var(--text-muted)', letterSpacing: '0.05em' }}>STEP {step.step_number}</div>
+          <div style={{ fontSize: 14, fontWeight: 800, color, marginTop: 2 }}>{meta.label}</div>
+          {step.tool_name && <code style={{ fontSize: 11.5, color: 'var(--text-secondary)', background: 'var(--bg-elevated)', padding: '2px 7px', borderRadius: 6, marginTop: 6, display: 'inline-block' }}>{step.tool_name}</code>}
+        </div>
+        <button onClick={onClose} style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 'var(--radius-md)', padding: 6, cursor: 'pointer', color: 'var(--text-muted)', flexShrink: 0 }}>
+          <X size={14} />
+        </button>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {step.status === 'pending_approval' && <Badge variant="warning" dot>Awaiting approval — use the node's Approve / Reject buttons</Badge>}
+        {step.status === 'rejected' && <Badge variant="neutral">Rejected</Badge>}
+
+        {!isFinal && step.reasoning && (
+          <div className="markdown-body" style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.6 }}>
+            <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{step.reasoning}</Markdown>
+          </div>
+        )}
+
+        {isFinal && (
+          <div className="markdown-body" style={{ fontSize: 13.5, color: 'var(--text-primary)', lineHeight: 1.6 }}>
+            <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{step.reasoning}</Markdown>
+          </div>
+        )}
+
+        {step.tool_args && (
+          <div>
+            <div style={{ fontSize: 10.5, fontWeight: 800, color: 'var(--text-muted)', letterSpacing: '0.05em', marginBottom: 5 }}>ARGUMENTS</div>
+            <pre style={{ margin: 0, padding: '9px 12px', background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)', fontSize: 11.5, color: 'var(--text-secondary)', overflowX: 'auto', fontFamily: 'var(--font-mono, monospace)' }}>
+              {prettyArgs(step.tool_args)}
+            </pre>
+          </div>
+        )}
+
+        {step.status === 'executed' && step.output && (
+          <div>
+            <div style={{ fontSize: 10.5, fontWeight: 800, color: 'var(--text-muted)', letterSpacing: '0.05em', marginBottom: 5 }}>OUTPUT</div>
+            <pre style={{ margin: 0, padding: '9px 12px', background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)', fontSize: 11.5, color: 'var(--text-primary)', overflowX: 'auto', maxHeight: 320, overflowY: 'auto', fontFamily: 'var(--font-mono, monospace)' }}>
+              {step.output}
+            </pre>
+          </div>
+        )}
+
+        {step.status === 'failed' && step.error_text && (
+          <div>
+            <div style={{ fontSize: 10.5, fontWeight: 800, color: 'var(--danger)', letterSpacing: '0.05em', marginBottom: 5 }}>ERROR</div>
+            <pre style={{ margin: 0, padding: '9px 12px', background: 'var(--bg-elevated)', border: '1px solid var(--danger)', borderRadius: 'var(--radius-md)', fontSize: 11.5, color: 'var(--danger)', overflowX: 'auto', maxHeight: 320, overflowY: 'auto', fontFamily: 'var(--font-mono, monospace)' }}>
+              {step.error_text}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -230,7 +230,7 @@ export function Agent() {
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [activeRun?.steps.length])
+  }, [activeRun?.steps?.length])
 
   const startRun = useCallback(async () => {
     if (!goal.trim() || !selectedServer || starting) return
@@ -384,7 +384,7 @@ export function Agent() {
                   )}
                 </div>
 
-                {activeRun.steps.map(step => (
+                {(activeRun.steps ?? []).map(step => (
                   <StepCard
                     key={step.id}
                     step={step}

--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -1,167 +1,42 @@
-import { useState, useEffect, useRef, useCallback, memo } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
-  Send, ChevronDown, Menu, Workflow, Terminal, Boxes, Bot,
-  CheckCircle2, XCircle, AlertTriangle, Ban, Loader, Check, X, StopCircle,
+  Menu, Workflow, Server, Hash, Clock, StopCircle, Cpu,
 } from 'lucide-react'
-import Markdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { api, buildWsUrl } from '../api/client'
 import { useToastStore } from '../store/toastStore'
+import { Badge } from '../components/ui'
 import { RunSidebar, type AgentRunSummary } from '../components/agent/RunSidebar'
+import { AgentFlowCanvas } from '../components/agent/AgentFlowCanvas'
+import { StepInspector } from '../components/agent/StepInspector'
+import { LauncherFlowCanvas } from '../components/agent/LauncherFlowCanvas'
+import type { AgentProvider } from '../components/agent/LauncherFlowNodes'
+import type { ServerData, AgentRun } from './agentTypes'
 
-interface ServerData { id: number; name: string; is_k8s?: boolean }
-
-interface AgentStep {
-  id: number
-  agent_run_id: number
-  step_number: number
-  kind: 'ssh_command' | 'mcp_tool' | 'final_answer' | 'unknown_tool'
-  tool_name: string
-  tool_args: string
-  reasoning: string
-  status: 'pending_approval' | 'approved' | 'rejected' | 'executed' | 'failed'
-  output: string
-  error_text: string
-  executed_at?: string
+const STATUS_BADGE: Record<AgentRun['status'], { label: string; variant: 'primary' | 'warning' | 'success' | 'danger' | 'neutral' }> = {
+  running: { label: 'Running', variant: 'primary' },
+  awaiting_approval: { label: 'Needs your approval', variant: 'warning' },
+  completed: { label: 'Completed', variant: 'success' },
+  failed: { label: 'Failed', variant: 'danger' },
+  cancelled: { label: 'Cancelled', variant: 'neutral' },
 }
 
-interface AgentRun extends AgentRunSummary {
-  server_id: number
-  provider: string
-  model: string
-  started_at: string
-  finished_at?: string
-  error_text: string
-  steps: AgentStep[]
+const PROVIDER_LABEL: Record<string, string> = {
+  claude: 'Claude',
+  openrouter: 'OpenRouter',
+  mistral: 'Mistral',
+  local: 'Local LLM',
 }
 
-const STATUS_BADGE: Record<AgentRun['status'], { label: string; color: string }> = {
-  running: { label: 'Running', color: 'var(--brand-primary)' },
-  awaiting_approval: { label: 'Needs your approval', color: 'var(--warning, #d97706)' },
-  completed: { label: 'Completed', color: 'var(--success)' },
-  failed: { label: 'Failed', color: 'var(--danger)' },
-  cancelled: { label: 'Cancelled', color: 'var(--text-muted)' },
+function timeAgo(iso?: string): string {
+  if (!iso) return ''
+  const diff = Date.now() - new Date(iso).getTime()
+  if (isNaN(diff) || diff < 0) return 'just now'
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  return `${hours}h ago`
 }
-
-function prettyArgs(raw: string): string {
-  try {
-    return JSON.stringify(JSON.parse(raw), null, 2)
-  } catch {
-    return raw
-  }
-}
-
-function kindMeta(kind: AgentStep['kind']) {
-  switch (kind) {
-    case 'ssh_command': return { label: 'SSH command', icon: Terminal, color: 'var(--info, #3b82f6)' }
-    case 'mcp_tool': return { label: 'Kubernetes / MCP tool', icon: Boxes, color: 'var(--brand-primary)' }
-    case 'unknown_tool': return { label: 'Unknown tool', icon: Ban, color: 'var(--danger)' }
-    default: return { label: 'Final answer', icon: Bot, color: 'var(--success)' }
-  }
-}
-
-const StepCard = memo(({ step, isBusy, onApprove, onReject }: {
-  step: AgentStep
-  isBusy: boolean
-  onApprove: (id: number) => void
-  onReject: (id: number) => void
-}) => {
-  if (step.kind === 'final_answer') {
-    return (
-      <div className="fade-up" style={{ display: 'flex', gap: 14, alignItems: 'flex-start' }}>
-        <div style={{ width: 34, height: 34, borderRadius: 'var(--radius-md)', background: 'var(--bg-card)', border: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-          <Bot size={16} color="var(--success)" />
-        </div>
-        <div style={{ flex: 1, minWidth: 0, background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: '14px 16px' }}>
-          <div className="markdown-body" style={{ fontSize: 13.5, color: 'var(--text-primary)', lineHeight: 1.6 }}>
-            <Markdown remarkPlugins={[remarkGfm]}>{step.reasoning}</Markdown>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  const meta = kindMeta(step.kind)
-  const Icon = meta.icon
-
-  return (
-    <div className="fade-up" style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', overflow: 'hidden' }}>
-      <div style={{ padding: '14px 16px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: 10 }}>
-        <span style={{ fontSize: 11.5, fontWeight: 800, color: 'var(--text-muted)', flexShrink: 0 }}>#{step.step_number}</span>
-        <Icon size={15} color={meta.color} />
-        <span style={{ fontSize: 12.5, fontWeight: 800, color: meta.color, textTransform: 'uppercase', letterSpacing: '0.04em' }}>{meta.label}</span>
-        {step.tool_name && (
-          <code style={{ fontSize: 12, color: 'var(--text-secondary)', background: 'var(--bg-elevated)', padding: '2px 8px', borderRadius: 6 }}>{step.tool_name}</code>
-        )}
-        <div style={{ flex: 1 }} />
-        {step.status === 'pending_approval' && <span style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--warning, #d97706)' }}>Awaiting approval</span>}
-        {step.status === 'executed' && <CheckCircle2 size={16} color="var(--success)" />}
-        {step.status === 'failed' && <AlertTriangle size={16} color="var(--danger)" />}
-        {step.status === 'rejected' && <XCircle size={16} color="var(--text-muted)" />}
-      </div>
-
-      <div style={{ padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
-        {step.reasoning && (
-          <div className="markdown-body" style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.6 }}>
-            <Markdown remarkPlugins={[remarkGfm]}>{step.reasoning}</Markdown>
-          </div>
-        )}
-
-        {step.tool_args && (
-          <pre style={{ margin: 0, padding: '10px 12px', background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)', fontSize: 12, color: 'var(--text-secondary)', overflowX: 'auto', fontFamily: 'var(--font-mono, monospace)' }}>
-            {prettyArgs(step.tool_args)}
-          </pre>
-        )}
-
-        {step.status === 'pending_approval' && (
-          <div style={{ display: 'flex', gap: 10 }}>
-            <button
-              disabled={isBusy}
-              onClick={() => onApprove(step.id)}
-              style={{
-                display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px', borderRadius: 'var(--radius-md)',
-                background: 'var(--brand-primary)', color: 'var(--text-inverse)', border: 'none', fontSize: 13, fontWeight: 800,
-                cursor: isBusy ? 'default' : 'pointer', opacity: isBusy ? 0.6 : 1,
-              }}
-            >
-              {isBusy ? <Loader size={14} className="spin" /> : <Check size={14} strokeWidth={3} />}
-              Approve &amp; run
-            </button>
-            <button
-              disabled={isBusy}
-              onClick={() => onReject(step.id)}
-              style={{
-                display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px', borderRadius: 'var(--radius-md)',
-                background: 'var(--bg-elevated)', color: 'var(--text-secondary)', border: '1px solid var(--border)', fontSize: 13, fontWeight: 800,
-                cursor: isBusy ? 'default' : 'pointer', opacity: isBusy ? 0.6 : 1,
-              }}
-            >
-              <X size={14} strokeWidth={3} />
-              Reject
-            </button>
-          </div>
-        )}
-
-        {step.status === 'executed' && step.output && (
-          <pre style={{ margin: 0, padding: '10px 12px', background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)', fontSize: 12, color: 'var(--text-primary)', overflowX: 'auto', maxHeight: 320, overflowY: 'auto', fontFamily: 'var(--font-mono, monospace)' }}>
-            {step.output}
-          </pre>
-        )}
-
-        {step.status === 'failed' && step.error_text && (
-          <pre style={{ margin: 0, padding: '10px 12px', background: 'var(--bg-elevated)', border: '1px solid var(--danger)', borderRadius: 'var(--radius-md)', fontSize: 12, color: 'var(--danger)', overflowX: 'auto', maxHeight: 320, overflowY: 'auto', fontFamily: 'var(--font-mono, monospace)' }}>
-            {step.error_text}
-          </pre>
-        )}
-
-        {step.status === 'rejected' && (
-          <div style={{ fontSize: 12.5, color: 'var(--text-muted)', fontWeight: 600 }}>Rejected — not executed.</div>
-        )}
-      </div>
-    </div>
-  )
-})
-StepCard.displayName = 'StepCard'
 
 export function Agent() {
   const [servers, setServers] = useState<ServerData[]>([])
@@ -171,12 +46,12 @@ export function Agent() {
   const [activeRun, setActiveRun] = useState<AgentRun | null>(null)
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
   const [goal, setGoal] = useState('')
+  const [provider, setProvider] = useState<AgentProvider>('claude')
   const [starting, setStarting] = useState(false)
   const [busyStepId, setBusyStepId] = useState<number | null>(null)
   const [cancelling, setCancelling] = useState(false)
-  const [inputFocused, setInputFocused] = useState(false)
+  const [selectedStepId, setSelectedStepId] = useState<number | null>(null)
 
-  const bottomRef = useRef<HTMLDivElement>(null)
   const toast = useToastStore()
 
   useEffect(() => {
@@ -206,6 +81,7 @@ export function Agent() {
   useEffect(() => {
     if (activeRunId == null) {
       setActiveRun(null)
+      setSelectedStepId(null)
       return
     }
     fetchActiveRun(activeRunId)
@@ -228,15 +104,18 @@ export function Agent() {
     return () => socket.close()
   }, [activeRunId, fetchActiveRun, fetchRuns])
 
+  // Auto-focus the newest pending step so the inspector opens itself as the run progresses.
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [activeRun?.steps?.length])
+    if (!activeRun) return
+    const pending = activeRun.steps?.find(s => s.status === 'pending_approval')
+    if (pending) setSelectedStepId(pending.id)
+  }, [activeRun])
 
   const startRun = useCallback(async () => {
     if (!goal.trim() || !selectedServer || starting) return
     setStarting(true)
     try {
-      const res = await api.post('/api/agent/runs', { goal: goal.trim(), server_id: Number(selectedServer) })
+      const res = await api.post('/api/agent/runs', { goal: goal.trim(), server_id: Number(selectedServer), provider })
       setGoal('')
       setActiveRunId(res.data.id)
       setActiveRun(res.data)
@@ -246,7 +125,7 @@ export function Agent() {
     } finally {
       setStarting(false)
     }
-  }, [goal, selectedServer, starting, fetchRuns, toast])
+  }, [goal, selectedServer, provider, starting, fetchRuns, toast])
 
   const approveStep = useCallback(async (stepId: number) => {
     if (!activeRunId) return
@@ -290,21 +169,23 @@ export function Agent() {
     }
   }, [activeRunId, fetchRuns, toast])
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      startRun()
+  const deleteRun = useCallback(async (id: number) => {
+    try {
+      await api.delete(`/api/agent/runs/${id}`)
+      if (id === activeRunId) {
+        setActiveRunId(null)
+        setActiveRun(null)
+      }
+      setRuns(prev => prev.filter(r => r.id !== id))
+    } catch (err: any) {
+      toast.error('Could not delete run', err.response?.data?.error || err.message)
     }
-  }
-
-  const selectStyle: React.CSSProperties = {
-    height: 34, padding: '0 26px 0 10px', borderRadius: 'var(--radius-md)',
-    background: 'var(--bg-elevated)', border: '1px solid var(--border)',
-    color: 'var(--text-primary)', fontSize: 13, fontWeight: 700,
-    cursor: 'pointer', outline: 'none', appearance: 'none', WebkitAppearance: 'none',
-  }
+  }, [activeRunId, toast])
 
   const activeServerName = servers.find(s => s.id === activeRun?.server_id)?.name
+  const isRunActive = activeRun && (activeRun.status === 'running' || activeRun.status === 'awaiting_approval')
+  const isLaunchable = !!goal.trim() && !!selectedServer && !starting
+  const selectedStep = activeRun?.steps?.find(s => s.id === selectedStepId) ?? null
 
   return (
     <div className={`ai-assistant-container ${isSidebarCollapsed ? 'sidebar-collapsed' : ''}`} style={{ display: 'flex', height: '100%', background: 'var(--bg-app)', position: 'relative' }}>
@@ -318,146 +199,124 @@ export function Agent() {
         activeRunId={activeRunId}
         onSelect={id => { setActiveRunId(id); if (window.innerWidth <= 768) setIsSidebarCollapsed(true) }}
         onNew={() => { setActiveRunId(null); if (window.innerWidth <= 768) setIsSidebarCollapsed(true) }}
+        onDelete={deleteRun}
         isCollapsed={isSidebarCollapsed}
         onToggle={setIsSidebarCollapsed}
       />
 
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', position: 'relative', minWidth: 0 }}>
-        <header className="ai-chat-header" style={{
-          width: '100%', padding: '12px 20px',
-          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-          flexShrink: 0, borderBottom: '1px solid var(--border)',
-          background: 'var(--bg-card)', flexWrap: 'wrap', gap: 12,
-        }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <button
-              className="show-mobile-only btn-icon"
-              onClick={() => setIsSidebarCollapsed(false)}
-              title="Runs"
-              style={{ padding: 8, background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)', border: '1px solid var(--border)' }}
-            >
-              <Menu size={16} />
-            </button>
+        <button
+          className="show-mobile-only btn-icon"
+          onClick={() => setIsSidebarCollapsed(false)}
+          title="Runs"
+          style={{ position: 'absolute', top: 14, left: 14, zIndex: 5, padding: 8, background: 'var(--bg-card)', borderRadius: 'var(--radius-md)', border: '1px solid var(--border)' }}
+        >
+          <Menu size={16} />
+        </button>
+
+        {activeRun ? (
+          <>
             <div style={{
-              width: 38, height: 38, borderRadius: 'var(--radius-md)',
-              background: 'var(--brand-glow)', border: '1px solid var(--brand-primary)',
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              padding: '14px 24px', borderBottom: '1px solid var(--border)',
+              background: 'var(--bg-card)', flexShrink: 0, zIndex: 2,
+              display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16, flexWrap: 'wrap',
             }}>
-              <Workflow size={18} color="var(--brand-primary)" />
-            </div>
-            <div>
-              <h1 style={{ fontSize: 15, fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.01em', lineHeight: 1.2 }}>Agent</h1>
-              <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 600 }}>
-                Human-approved DevOps automation{activeServerName ? <> · <span style={{ color: 'var(--text-secondary)' }}>{activeServerName}</span></> : null}
-              </div>
-            </div>
-          </div>
-
-          {activeRun && (activeRun.status === 'running' || activeRun.status === 'awaiting_approval') && (
-            <button
-              onClick={cancelRun}
-              disabled={cancelling}
-              style={{
-                display: 'flex', alignItems: 'center', gap: 6, padding: '8px 14px', borderRadius: 'var(--radius-md)',
-                background: 'var(--bg-elevated)', border: '1px solid var(--border)', color: 'var(--danger)',
-                fontSize: 12.5, fontWeight: 800, cursor: cancelling ? 'default' : 'pointer', opacity: cancelling ? 0.6 : 1,
-              }}
-            >
-              <StopCircle size={14} /> Cancel run
-            </button>
-          )}
-        </header>
-
-        <div style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', padding: '24px 16px 150px' }}>
-          <div style={{ maxWidth: 860, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16, minWidth: 0 }}>
-
-            {activeRun ? (
-              <>
-                <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-                  <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1.5 }}>{activeRun.goal}</div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                    <span style={{ width: 7, height: 7, borderRadius: '50%', background: STATUS_BADGE[activeRun.status].color }} />
-                    <span style={{ fontSize: 12, fontWeight: 800, color: STATUS_BADGE[activeRun.status].color }}>{STATUS_BADGE[activeRun.status].label}</span>
-                  </div>
-                  {activeRun.status === 'failed' && activeRun.error_text && (
-                    <div style={{ fontSize: 12.5, color: 'var(--danger)', fontWeight: 600 }}>{activeRun.error_text}</div>
-                  )}
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0, flex: 1 }}>
+                <div style={{ fontSize: 15, fontWeight: 800, color: 'var(--text-primary)', lineHeight: 1.4 }}>{activeRun.goal}</div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' }}>
+                  <Badge variant={STATUS_BADGE[activeRun.status].variant} dot>{STATUS_BADGE[activeRun.status].label}</Badge>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12.5, color: 'var(--text-muted)', fontWeight: 600 }}>
+                    <Server size={12.5} /> {activeServerName ?? `Server #${activeRun.server_id}`}
+                  </span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12.5, color: 'var(--text-muted)', fontWeight: 600 }}>
+                    <Hash size={12.5} /> {activeRun.steps?.length ?? 0} step{(activeRun.steps?.length ?? 0) === 1 ? '' : 's'}
+                  </span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12.5, color: 'var(--text-muted)', fontWeight: 600 }}>
+                    <Clock size={12.5} /> started {timeAgo(activeRun.started_at)}
+                  </span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12.5, color: 'var(--text-muted)', fontWeight: 600 }}>
+                    <Cpu size={12.5} /> {PROVIDER_LABEL[activeRun.provider] ?? activeRun.provider}
+                    {activeRun.model ? ` · ${activeRun.model}` : ''}
+                  </span>
                 </div>
-
-                {(activeRun.steps ?? []).map(step => (
-                  <StepCard
-                    key={step.id}
-                    step={step}
-                    isBusy={busyStepId === step.id}
-                    onApprove={approveStep}
-                    onReject={rejectStep}
-                  />
-                ))}
-
-                {activeRun.status === 'running' && (
-                  <div style={{ display: 'flex', gap: 10, alignItems: 'center', color: 'var(--text-muted)', fontSize: 13, fontWeight: 600 }}>
-                    <Loader size={14} className="spin" /> Thinking…
-                  </div>
+                {activeRun.status === 'failed' && activeRun.error_text && (
+                  <div style={{ fontSize: 12.5, color: 'var(--danger)', fontWeight: 600 }}>{activeRun.error_text}</div>
                 )}
-
-                <div ref={bottomRef} />
-              </>
-            ) : (
-              <div className="fade-in" style={{ padding: '8px 0 8px' }}>
-                <h2 style={{ fontSize: 13, color: 'var(--text-muted)', fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 14 }}>
-                  What should the Agent do?
-                </h2>
-                <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: 16, fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.6 }}>
-                  Describe a goal — e.g. "restart the nginx service" or "scale the checkout deployment to 3 replicas" —
-                  and pick the target server below. The Agent proposes one SSH or Kubernetes action at a time; nothing
-                  runs until you approve it.
-                </div>
               </div>
-            )}
-          </div>
-        </div>
 
-        {!activeRun && (
-          <div className="ai-input-wrapper" style={{ position: 'absolute', bottom: 0, left: 0, right: 0, padding: '20px', background: 'linear-gradient(to top, var(--bg-app) 55%, transparent)', pointerEvents: 'none' }}>
-            <div style={{ maxWidth: 860, margin: '0 auto', pointerEvents: 'auto' }}>
-              <div className="chat-input-container" style={{
-                background: 'var(--bg-input)',
-                border: `1px solid ${inputFocused ? 'var(--brand-primary)' : 'var(--border)'}`,
-                borderRadius: 'var(--radius-lg)', padding: '12px 14px',
-                display: 'flex', gap: 10, alignItems: 'flex-end',
-                boxShadow: inputFocused ? '0 0 0 3px var(--brand-glow)' : 'var(--shadow-sm, none)',
-                transition: 'border-color 0.15s, box-shadow 0.15s',
-              }}>
-                <textarea
-                  value={goal} onChange={e => setGoal(e.target.value)} onKeyDown={handleKeyDown}
-                  onFocus={() => setInputFocused(true)} onBlur={() => setInputFocused(false)}
-                  placeholder="Describe the goal for the Agent…"
-                  disabled={starting} rows={1}
-                  style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', color: 'var(--text-primary)', fontSize: 13, padding: '8px 0', resize: 'none', lineHeight: 1.6, maxHeight: 150 }}
-                  onInput={e => { const el = e.currentTarget; el.style.height = 'auto'; el.style.height = Math.min(el.scrollHeight, 150) + 'px' }}
-                />
-                <div style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
-                  <select value={selectedServer} onChange={e => setSelectedServer(Number(e.target.value) || '')} title="Target server" style={{ ...selectStyle, maxWidth: 180 }}>
-                    <option value="">Select server…</option>
-                    {servers.map(s => <option key={s.id} value={s.id}>{s.is_k8s ? '☸ ' : ''}{s.name}</option>)}
-                  </select>
-                  <ChevronDown size={13} color="var(--text-muted)" style={{ position: 'absolute', right: 8, pointerEvents: 'none' }} />
-                </div>
-                <button onClick={startRun} disabled={!goal.trim() || !selectedServer || starting} title="Start agent run (Enter)"
-                  style={{ width: 38, height: 38, borderRadius: 'var(--radius-md)', flexShrink: 0, background: goal.trim() && selectedServer && !starting ? 'var(--brand-primary)' : 'var(--bg-elevated)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', border: 'none', transition: 'all 0.2s' }}>
-                  {starting ? <Loader size={16} className="spin" color="var(--text-muted)" /> : <Send size={16} color={goal.trim() && selectedServer ? 'var(--text-inverse)' : 'var(--text-muted)'} />}
+              {isRunActive && (
+                <button
+                  onClick={cancelRun}
+                  disabled={cancelling}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 6, padding: '9px 14px', borderRadius: 'var(--radius-md)',
+                    background: 'var(--bg-elevated)', border: '1px solid var(--border)', color: 'var(--danger)',
+                    fontSize: 12.5, fontWeight: 800, cursor: cancelling ? 'default' : 'pointer', opacity: cancelling ? 0.6 : 1, flexShrink: 0,
+                  }}
+                >
+                  <StopCircle size={14} /> Cancel run
                 </button>
+              )}
+            </div>
+
+            <div style={{ flex: 1, position: 'relative', minHeight: 0 }}>
+              <AgentFlowCanvas
+                run={activeRun}
+                selectedStepId={selectedStepId}
+                onSelectStep={setSelectedStepId}
+                onApprove={approveStep}
+                onReject={rejectStep}
+                busyStepId={busyStepId}
+              />
+              {selectedStep && (
+                <StepInspector
+                  step={selectedStep}
+                  onClose={() => setSelectedStepId(null)}
+                />
+              )}
+            </div>
+          </>
+        ) : (
+          <>
+            <div style={{
+              padding: '14px 24px', borderBottom: '1px solid var(--border)',
+              background: 'var(--bg-card)', flexShrink: 0, zIndex: 2,
+              display: 'flex', alignItems: 'center', gap: 12,
+            }}>
+              <div style={{
+                width: 36, height: 36, borderRadius: 'var(--radius-md)',
+                background: 'var(--brand-glow)', border: '1px solid var(--brand-primary)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+              }}>
+                <Workflow size={18} color="var(--brand-primary)" />
               </div>
-              <div className="hidden-mobile" style={{ display: 'flex', justifyContent: 'center', gap: 14, marginTop: 8, fontSize: 12.5, color: 'var(--text-muted)', fontWeight: 600 }}>
-                <span>Enter to start · Shift+Enter for a new line · every action needs your approval</span>
+              <div>
+                <div style={{ fontSize: 15, fontWeight: 800, color: 'var(--text-primary)' }}>New Agent Run</div>
+                <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 600 }}>Connect a server, provider, and goal — then trigger to launch. Every SSH or Kubernetes action is proposed first, nothing runs without your approval.</div>
               </div>
             </div>
-          </div>
+            <div style={{ flex: 1, position: 'relative', minHeight: 0 }}>
+              <LauncherFlowCanvas
+                servers={servers}
+                selectedServer={selectedServer}
+                onSelectServer={setSelectedServer}
+                provider={provider}
+                onSelectProvider={setProvider}
+                goal={goal}
+                onGoalChange={setGoal}
+                onLaunch={startRun}
+                isLaunchable={isLaunchable}
+                starting={starting}
+              />
+            </div>
+          </>
         )}
       </div>
       <style>{`
         @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         .spin { animation: spin 1s linear infinite; }
+        @keyframes agentNodePulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+        .agent-node-pulse { animation: agentNodePulse 1.4s ease-in-out infinite; }
       `}</style>
     </div>
   )

--- a/frontend/src/pages/agentTypes.ts
+++ b/frontend/src/pages/agentTypes.ts
@@ -1,0 +1,27 @@
+import type { AgentRunSummary } from '../components/agent/RunSidebar'
+
+export interface ServerData { id: number; name: string; is_k8s?: boolean }
+
+export interface AgentStep {
+  id: number
+  agent_run_id: number
+  step_number: number
+  kind: 'ssh_command' | 'mcp_tool' | 'final_answer' | 'unknown_tool'
+  tool_name: string
+  tool_args: string
+  reasoning: string
+  status: 'pending_approval' | 'approved' | 'rejected' | 'executed' | 'failed'
+  output: string
+  error_text: string
+  executed_at?: string
+}
+
+export interface AgentRun extends AgentRunSummary {
+  server_id: number
+  provider: string
+  model: string
+  started_at: string
+  finished_at?: string
+  error_text: string
+  steps: AgentStep[]
+}


### PR DESCRIPTION
## Summary
- Fixes a crash ("undefined is not an object (evaluating 'c?.steps.length')") caused by `AgentRun.Steps` serializing as omitted/null on zero-step runs.
- Node-graph launcher canvas (server / provider / goal / trigger nodes) replacing the previous form layout — also fixes a bug where the server/provider dropdowns and goal textarea didn't respond to input (React Flow was setting `pointer-events: none` on non-selectable/non-draggable nodes).
- Multi-provider agent dispatch: local LLM, OpenRouter, and Mistral alongside the existing Claude tool-calling path.
- Delete agent runs from the sidebar (`DELETE /api/agent/runs/:id` + inline confirm UI, matching the existing alert-rule delete pattern).
- Fixed unstyled/congested markdown rendering in the step inspector's final-answer panel.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `npx tsc -b` clean
- [ ] Manual smoke test after merge: launch a run, confirm dropdowns/textarea are interactive, delete a run, check final-answer markdown spacing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>