### PR TITLE
feat(infra-map): infrastructure blueprint with real network topology

### DIFF
--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -46,6 +46,7 @@ func Connect() {
 		&models.ResourceAccess{},
 		&models.ResourceAudit{},
 		&models.ResourceMetric{},
+		&models.NetworkScan{},
 		&models.Metric{},
 		&models.LogEntry{},
 		&models.AlertRule{},

--- a/backend/internal/handlers/topology.go
+++ b/backend/internal/handlers/topology.go
@@ -1,0 +1,939 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/infra-eye/backend/internal/db"
+	"github.com/infra-eye/backend/internal/k8s"
+	"github.com/infra-eye/backend/internal/models"
+	sshpool "github.com/infra-eye/backend/internal/ssh"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The topology endpoint assembles the full infrastructure blueprint: every
+// server, cluster, and cataloged resource the requesting user may see, the
+// edges between them, and the network segments they sit on. Static edges
+// (management links, resource placement by matching hosts) come straight from
+// the database; network membership is derived from declared addresses (plus
+// DNS resolution). With ?live=true it also SSHes into each reachable server
+// to read established TCP connections and the real interface CIDRs, and lists
+// the nodes of each connected Kubernetes cluster. With ?live=true&discover=true
+// it additionally runs an nmap ping sweep (from one server per real segment)
+// to surface other real devices on that network InfraEye doesn't manage —
+// only ever run on explicit opt-in, since it actively probes the network.
+// Real observed state is never cached across requests (see
+// docs/DESIGN_PRINCIPLES.md); scan failures are reported verbatim in Notes
+// rather than swallowed.
+
+type TopologyNode struct {
+	ID           string   `json:"id"`
+	Kind         string   `json:"kind"` // core | server | cluster | resource | k8s_node | discovered
+	RefID        uint     `json:"ref_id,omitempty"`
+	Name         string   `json:"name"`
+	Host         string   `json:"host,omitempty"`
+	Port         int      `json:"port,omitempty"`
+	Status       string   `json:"status,omitempty"`
+	OS           string   `json:"os,omitempty"`
+	Distro       string   `json:"distro,omitempty"`
+	ResourceType string   `json:"resource_type,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	FolderID     *uint    `json:"folder_id,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
+	Detail       string   `json:"detail,omitempty"`
+	// Networks lists the IDs of every TopologyNetwork this node has an
+	// address on (first entry is the primary placement in the map).
+	Networks []string `json:"networks,omitempty"`
+}
+
+type TopologyEdge struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Kind   string `json:"kind"` // manage | hosted_on | network | member | discovered
+	Label  string `json:"label,omitempty"`
+}
+
+// TopologyNetwork is one network segment nodes can belong to. Segments come
+// from real interface CIDRs when a live scan provided them (Source names the
+// servers they were read from); otherwise private IPv4 addresses are bucketed
+// into an assumed /24 — labeled as such, since it is a guess, not a fact.
+type TopologyNetwork struct {
+	ID     string `json:"id"`
+	CIDR   string `json:"cidr"`
+	Label  string `json:"label"`
+	Kind   string `json:"kind"` // private | vpn | public | loopback
+	Source string `json:"source,omitempty"`
+}
+
+type TopologyGraph struct {
+	GeneratedAt time.Time         `json:"generated_at"`
+	Live        bool              `json:"live"`
+	Folders     []models.Folder   `json:"folders"`
+	Networks    []TopologyNetwork `json:"networks"`
+	Nodes       []TopologyNode    `json:"nodes"`
+	Edges       []TopologyEdge    `json:"edges"`
+	Notes       []string          `json:"notes,omitempty"`
+}
+
+const topologyScanTimeout = 12 * time.Second
+
+// Established-connections scripts print one "ip:port" remote endpoint per line.
+const linuxEstabScript = `
+if command -v ss >/dev/null 2>&1; then
+  ss -Htn state established 2>/dev/null | awk '{print $4}'
+elif command -v netstat >/dev/null 2>&1; then
+  netstat -tn 2>/dev/null | awk '$6=="ESTABLISHED"{print $5}'
+fi
+`
+
+const darwinEstabScript = `netstat -an -p tcp 2>/dev/null | awk '$6=="ESTABLISHED"{print $5}'`
+
+const windowsEstabScript = `powershell -NoProfile -NonInteractive -Command "Get-NetTCPConnection -State Established -ErrorAction SilentlyContinue | ForEach-Object { $_.RemoteAddress + ':' + $_.RemotePort }"`
+
+// Interface scripts print one IPv4 address per line, with its prefix:
+// "10.0.0.11/24" on linux/windows, "10.0.0.11 0xffffff00" on macOS.
+// The linux form avoids `ip -o` and scope filters so it also works on
+// busybox (Alpine containers); loopback/link-local are filtered Go-side.
+const linuxIfaceNetScript = `
+if command -v ip >/dev/null 2>&1; then
+  ip -4 addr show 2>/dev/null | awk '/inet /{print $2}'
+elif command -v ifconfig >/dev/null 2>&1; then
+  ifconfig 2>/dev/null | awk '/inet / && $2 != "127.0.0.1" {print $2, $4}'
+fi
+`
+
+const darwinIfaceNetScript = `ifconfig 2>/dev/null | awk '/inet / && $2 != "127.0.0.1" {print $2, $4}'`
+
+const windowsIfaceNetScript = `powershell -NoProfile -NonInteractive -Command "Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.IPAddress -notlike '127.*' -and $_.IPAddress -notlike '169.254.*' } | ForEach-Object { $_.IPAddress + '/' + $_.PrefixLength }"`
+
+func GetTopology(c *gin.Context) {
+	role := c.GetString("role")
+	userID := c.GetUint("user_id")
+	live := c.Query("live") == "true"
+	discover := live && c.Query("discover") == "true"
+
+	var servers []models.Server
+	if role == "admin" || role == "devops" {
+		db.DB.Find(&servers)
+	} else {
+		db.DB.Joins("JOIN server_accesses ON server_accesses.server_id = servers.id AND server_accesses.user_id = ? AND server_accesses.deleted_at IS NULL", userID).
+			Find(&servers)
+	}
+
+	// Resource visibility matches the /api/resources route gate.
+	var resources []models.Resource
+	if role == "admin" || role == "devops" || role == "trainee" {
+		db.DB.Find(&resources)
+	}
+
+	var folders []models.Folder
+	db.DB.Find(&folders)
+
+	graph := TopologyGraph{
+		GeneratedAt: time.Now(),
+		Live:        live,
+		Folders:     folders,
+		Networks:    []TopologyNetwork{},
+		Nodes:       []TopologyNode{},
+		Edges:       []TopologyEdge{},
+	}
+
+	graph.Nodes = append(graph.Nodes, TopologyNode{
+		ID:     "infraeye",
+		Kind:   "core",
+		Name:   "InfraEye",
+		Detail: "control plane",
+	})
+
+	// hostToNode maps every declared address to the node that owns it, for
+	// matching observed connections and resource placement.
+	hostToNode := map[string]string{}
+	nodePort := map[string]int{}
+
+	for _, s := range servers {
+		id := fmt.Sprintf("server-%d", s.ID)
+		kind := "server"
+		if s.IsK8s {
+			kind = "cluster"
+		}
+		node := TopologyNode{
+			ID:       id,
+			Kind:     kind,
+			RefID:    s.ID,
+			Name:     s.Name,
+			Host:     s.Host,
+			Port:     s.Port,
+			Status:   s.Status,
+			OS:       s.OS,
+			Distro:   s.Distro,
+			FolderID: s.FolderID,
+			Tags:     splitTags(s.Tags),
+			Detail:   s.DistroPrettyName,
+		}
+		graph.Nodes = append(graph.Nodes, node)
+		if s.Host != "" {
+			hostToNode[s.Host] = id
+		}
+
+		label := ""
+		switch {
+		case s.IsK8s && s.Host != "":
+			label = fmt.Sprintf("SSH :%d + kubeconfig", s.Port)
+		case s.IsK8s:
+			label = "kubeconfig"
+		default:
+			label = fmt.Sprintf("SSH :%d", s.Port)
+		}
+		graph.Edges = append(graph.Edges, TopologyEdge{
+			Source: "infraeye", Target: id, Kind: "manage", Label: label,
+		})
+	}
+
+	for _, r := range resources {
+		id := fmt.Sprintf("resource-%d", r.ID)
+		graph.Nodes = append(graph.Nodes, TopologyNode{
+			ID:           id,
+			Kind:         "resource",
+			RefID:        r.ID,
+			Name:         r.Name,
+			Host:         r.Host,
+			Port:         r.Port,
+			Status:       r.Status,
+			ResourceType: r.ResourceType,
+			Protocol:     r.Protocol,
+			FolderID:     r.FolderID,
+			Tags:         splitTags(r.Tags),
+		})
+		if r.Host != "" {
+			// Servers claim the address first; don't let a resource shadow one.
+			if _, taken := hostToNode[r.Host]; !taken {
+				hostToNode[r.Host] = id
+			}
+			nodePort[id] = r.Port
+		}
+
+		// A resource whose host is a managed server lives on that server;
+		// otherwise InfraEye probes it directly (or via the gateway).
+		if serverNode, ok := hostToNode[r.Host]; ok && strings.HasPrefix(serverNode, "server-") {
+			graph.Edges = append(graph.Edges, TopologyEdge{
+				Source: id, Target: serverNode, Kind: "hosted_on",
+				Label: fmt.Sprintf("%s :%d", r.Protocol, r.Port),
+			})
+		} else {
+			label := "probe"
+			if r.UseGateway {
+				label = "probe via gateway"
+			}
+			graph.Edges = append(graph.Edges, TopologyEdge{
+				Source: "infraeye", Target: id, Kind: "manage", Label: label,
+			})
+		}
+	}
+
+	// Resolve every declared host to IPs (literal IPs parse immediately, DNS
+	// names get a short concurrent lookup) so hostname-addressed machines
+	// still land on the right network segment and match observed traffic.
+	nodeIPs, ipToNode := resolveNodeAddresses(hostToNode)
+
+	// ifaceNets holds the real interface CIDRs known for each server, keyed
+	// by node ID; scanTimes records when each set was read. Cached results
+	// from earlier live scans seed the map so the network view shows real
+	// segments even on a plain page load; a live scan re-reads and replaces
+	// them.
+	ifaceNets := map[string][]*net.IPNet{}
+	scanTimes := map[string]time.Time{}
+	// selfIPs holds each server's exact interface addresses (unmasked), so
+	// discovery can recognize "this nmap hit is the scanning server itself"
+	// even when the server's declared host (how InfraEye reaches it — a
+	// port-forward, NAT, or localhost mapping) differs from its real IP.
+	selfIPs := map[string][]net.IP{}
+	serverIDs := make([]uint, 0, len(servers))
+	for _, s := range servers {
+		serverIDs = append(serverIDs, s.ID)
+	}
+	var cached []models.NetworkScan
+	if len(serverIDs) > 0 {
+		db.DB.Where("server_id IN ?", serverIDs).Find(&cached)
+	}
+	for _, ns := range cached {
+		id := fmt.Sprintf("server-%d", ns.ServerID)
+		var cidrs []string
+		if err := json.Unmarshal([]byte(ns.CIDRs), &cidrs); err != nil {
+			continue
+		}
+		for _, c := range cidrs {
+			if _, n, err := net.ParseCIDR(c); err == nil {
+				ifaceNets[id] = append(ifaceNets[id], n)
+			}
+		}
+		scanTimes[id] = ns.ScannedAt
+	}
+
+	if live {
+		runLiveScans(&graph, servers, ipToNode, nodePort, ifaceNets, scanTimes, selfIPs)
+	}
+
+	buildNetworks(&graph, nodeIPs, ifaceNets, scanTimes)
+
+	if discover {
+		runNetworkDiscovery(&graph, servers, ifaceNets, ipToNode, selfIPs)
+	}
+
+	c.JSON(http.StatusOK, graph)
+}
+
+// resolveNodeAddresses turns declared hosts into IPs per node, plus the
+// reverse ip→node index used to match observed connections. DNS lookups run
+// concurrently with a short timeout so unresolvable names can't stall the map.
+func resolveNodeAddresses(hostToNode map[string]string) (map[string][]net.IP, map[string]string) {
+	nodeIPs := map[string][]net.IP{}
+	ipToNode := map[string]string{}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for host, nodeID := range hostToNode {
+		ipToNode[host] = nodeID
+		if ip := net.ParseIP(host); ip != nil {
+			nodeIPs[nodeID] = append(nodeIPs[nodeID], ip)
+			continue
+		}
+		wg.Add(1)
+		go func(host, nodeID string) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			addrs, err := net.DefaultResolver.LookupHost(ctx, host)
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, a := range addrs {
+				if ip := net.ParseIP(a); ip != nil {
+					nodeIPs[nodeID] = append(nodeIPs[nodeID], ip)
+				}
+				if _, taken := ipToNode[a]; !taken {
+					ipToNode[a] = nodeID
+				}
+			}
+		}(host, nodeID)
+	}
+	wg.Wait()
+	return nodeIPs, ipToNode
+}
+
+// runLiveScans enriches the graph with observed TCP connections between known
+// hosts, real interface networks, and the member nodes of each connected
+// Kubernetes cluster. All scans run concurrently; each failure is appended to
+// graph.Notes verbatim.
+func runLiveScans(graph *TopologyGraph, servers []models.Server, ipToNode map[string]string, nodePort map[string]int, ifaceNets map[string][]*net.IPNet, scanTimes map[string]time.Time, selfIPs map[string][]net.IP) {
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 8)
+
+	edgeSeen := map[string]bool{}
+	for _, e := range graph.Edges {
+		edgeSeen[e.Source+"|"+e.Target+"|"+e.Kind] = true
+	}
+	addEdge := func(e TopologyEdge) {
+		mu.Lock()
+		defer mu.Unlock()
+		key := e.Source + "|" + e.Target + "|" + e.Kind
+		revKey := e.Target + "|" + e.Source + "|" + e.Kind
+		if edgeSeen[key] || (e.Kind == "network" && edgeSeen[revKey]) {
+			return
+		}
+		edgeSeen[key] = true
+		graph.Edges = append(graph.Edges, e)
+	}
+	addNote := func(format string, args ...interface{}) {
+		mu.Lock()
+		defer mu.Unlock()
+		graph.Notes = append(graph.Notes, fmt.Sprintf(format, args...))
+	}
+	// A fresh read replaces whatever the cache had for that server.
+	addIfaceNets := func(nodeID string, addrs []ifaceAddr) {
+		mu.Lock()
+		defer mu.Unlock()
+		nets := make([]*net.IPNet, 0, len(addrs))
+		ips := make([]net.IP, 0, len(addrs))
+		for _, a := range addrs {
+			nets = append(nets, a.Net)
+			ips = append(ips, a.IP)
+		}
+		ifaceNets[nodeID] = nets
+		selfIPs[nodeID] = ips
+		scanTimes[nodeID] = time.Now()
+	}
+
+	for _, s := range servers {
+		if s.Host != "" {
+			wg.Add(1)
+			go func(s models.Server) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				scanServer(s, ipToNode, nodePort, addEdge, addNote, addIfaceNets)
+			}(s)
+		}
+		if s.IsK8s && s.K8sConnected && s.KubeConfig != "" {
+			wg.Add(1)
+			go func(s models.Server) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				scanClusterNodes(s, graph, &mu, addNote)
+			}(s)
+		}
+	}
+	wg.Wait()
+}
+
+func scanServer(s models.Server, ipToNode map[string]string, nodePort map[string]int, addEdge func(TopologyEdge), addNote func(string, ...interface{}), addIfaceNets func(string, []ifaceAddr)) {
+	client, err := sshpool.GetOrCreate(s.ID, s.Host, s.Port, s.SSHUser, s.SSHKeyPath, s.SSHPassword, s.AuthType)
+	if err != nil {
+		addNote("%s: SSH connection failed: %v", s.Name, err)
+		return
+	}
+	selfID := fmt.Sprintf("server-%d", s.ID)
+
+	estabScript := linuxEstabScript
+	ifaceScript := linuxIfaceNetScript
+	switch s.OS {
+	case "darwin":
+		estabScript = darwinEstabScript
+		ifaceScript = darwinIfaceNetScript
+	case "windows":
+		estabScript = windowsEstabScript
+		ifaceScript = windowsIfaceNetScript
+	}
+
+	// ── Interface networks: which segments is this machine actually on? ──
+	ifaceOut, _, err := client.RunCommandTimeout(ifaceScript, topologyScanTimeout)
+	if err != nil {
+		addNote("%s: interface scan failed: %v", s.Name, err)
+	} else {
+		addrs := parseIfaceNets(ifaceOut)
+		addIfaceNets(selfID, addrs)
+		// Persist so plain (non-live) loads keep showing the real segments.
+		cidrs := make([]string, 0, len(addrs))
+		for _, a := range addrs {
+			cidrs = append(cidrs, a.Net.String())
+		}
+		if b, err := json.Marshal(cidrs); err == nil {
+			if err := db.DB.Save(&models.NetworkScan{ServerID: s.ID, CIDRs: string(b), ScannedAt: time.Now()}).Error; err != nil {
+				addNote("%s: caching interface scan failed: %v", s.Name, err)
+			}
+		}
+	}
+
+	// ── Established TCP connections to other known hosts ──
+	out, _, err := client.RunCommandTimeout(estabScript, topologyScanTimeout)
+	if err != nil {
+		addNote("%s: connection scan failed: %v", s.Name, err)
+		return
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		ip, port := splitRemoteAddr(strings.TrimSpace(line))
+		if ip == "" {
+			continue
+		}
+		target, known := ipToNode[ip]
+		if !known || target == selfID {
+			continue
+		}
+		// Skip the ephemeral (client) side of connections to a resource: only
+		// the resource's own service port is meaningful on the map.
+		if want, ok := nodePort[target]; ok && want != 0 && port != fmt.Sprintf("%d", want) {
+			continue
+		}
+		label := ""
+		if port != "" {
+			label = "tcp :" + port
+			if svc := describePort(":" + port); svc != "" {
+				label = svc + " :" + port
+			}
+		}
+		addEdge(TopologyEdge{Source: selfID, Target: target, Kind: "network", Label: label})
+	}
+}
+
+func scanClusterNodes(s models.Server, graph *TopologyGraph, mu *sync.Mutex, addNote func(string, ...interface{})) {
+	clientset, err := k8s.GetK8sClient(s.KubeConfig)
+	if err != nil {
+		addNote("%s: kubeconfig error: %v", s.Name, err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		addNote("%s: listing cluster nodes failed: %v", s.Name, err)
+		return
+	}
+
+	clusterID := fmt.Sprintf("server-%d", s.ID)
+	for _, n := range nodes.Items {
+		status := "offline"
+		for _, cond := range n.Status.Conditions {
+			if cond.Type == "Ready" && cond.Status == "True" {
+				status = "online"
+			}
+		}
+		role := "worker"
+		if _, ok := n.Labels["node-role.kubernetes.io/control-plane"]; ok {
+			role = "control-plane"
+		} else if _, ok := n.Labels["node-role.kubernetes.io/master"]; ok {
+			role = "control-plane"
+		}
+		var addr string
+		for _, a := range n.Status.Addresses {
+			if a.Type == "InternalIP" {
+				addr = a.Address
+			}
+		}
+		nodeID := fmt.Sprintf("k8snode-%d-%s", s.ID, n.Name)
+		mu.Lock()
+		graph.Nodes = append(graph.Nodes, TopologyNode{
+			ID:     nodeID,
+			Kind:   "k8s_node",
+			RefID:  s.ID,
+			Host:   addr,
+			Name:   n.Name,
+			Status: status,
+			Detail: role + " · " + n.Status.NodeInfo.KubeletVersion,
+		})
+		graph.Edges = append(graph.Edges, TopologyEdge{
+			Source: clusterID, Target: nodeID, Kind: "member", Label: role,
+		})
+		mu.Unlock()
+	}
+}
+
+// ── Network discovery (nmap) ──
+
+const nmapScanTimeout = 45 * time.Second
+
+// maxDiscoveryHosts caps how large a segment discovery will probe — an
+// active ping sweep is intrusive and shouldn't silently balloon into
+// scanning a /16. Anything bigger is skipped with a note explaining why.
+const maxDiscoveryHosts = 1024
+
+const nmapScript = `
+if command -v nmap >/dev/null 2>&1; then
+  nmap -sn -T4 --max-retries 1 %s 2>&1
+else
+  echo "__NMAP_NOT_FOUND__"
+fi
+`
+
+// runNetworkDiscovery ping-sweeps each real (SSH-scanned) network segment
+// from one server that sits on it, surfacing devices InfraEye doesn't manage
+// — the rest of what's actually on the wire, not just what's registered.
+// Only ever called on explicit ?discover=true opt-in.
+func runNetworkDiscovery(graph *TopologyGraph, servers []models.Server, ifaceNets map[string][]*net.IPNet, ipToNode map[string]string, selfIPs map[string][]net.IP) {
+	serverByNodeID := map[string]models.Server{}
+	for _, s := range servers {
+		serverByNodeID[fmt.Sprintf("server-%d", s.ID)] = s
+	}
+
+	// Known addresses: anything already represented on the map (declared
+	// hosts, resolved DNS IPs, and every scanned server's own real IPs)
+	// should never turn into a duplicate "discovered" node.
+	known := map[string]bool{}
+	for ipStr := range ipToNode {
+		if net.ParseIP(ipStr) != nil {
+			known[ipStr] = true
+		}
+	}
+	for _, ips := range selfIPs {
+		for _, ip := range ips {
+			known[ip.String()] = true
+		}
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	seenDiscovered := map[string]bool{}
+
+	// One scan per unique real segment, run from the first server we find
+	// that has an interface on it — scanning from every member would be
+	// redundant (and, for a bridge/L2 network, give the same answer).
+	scannedCIDR := map[string]bool{}
+	for nodeID, nets := range ifaceNets {
+		s, ok := serverByNodeID[nodeID]
+		if !ok {
+			continue
+		}
+		for _, n := range nets {
+			masked := &net.IPNet{IP: n.IP.Mask(n.Mask), Mask: n.Mask}
+			cidr := masked.String()
+			mu.Lock()
+			already := scannedCIDR[cidr]
+			if !already {
+				scannedCIDR[cidr] = true
+			}
+			mu.Unlock()
+			if already {
+				continue
+			}
+
+			ones, bits := masked.Mask.Size()
+			if hostBits := bits - ones; hostBits > 0 && (1<<uint(hostBits)) > maxDiscoveryHosts {
+				mu.Lock()
+				graph.Notes = append(graph.Notes, fmt.Sprintf(
+					"%s: %s is too large for a discovery scan (%d addresses) — skipping", s.Name, cidr, 1<<uint(hostBits)))
+				mu.Unlock()
+				continue
+			}
+
+			netID := "net-" + cidr
+			wg.Add(1)
+			go func(s models.Server, cidr, netID string) {
+				defer wg.Done()
+				discoverOnSegment(s, cidr, netID, known, graph, &mu, seenDiscovered)
+			}(s, cidr, netID)
+		}
+	}
+	wg.Wait()
+}
+
+func discoverOnSegment(s models.Server, cidr, netID string, known map[string]bool, graph *TopologyGraph, mu *sync.Mutex, seenDiscovered map[string]bool) {
+	client, err := sshpool.GetOrCreate(s.ID, s.Host, s.Port, s.SSHUser, s.SSHKeyPath, s.SSHPassword, s.AuthType)
+	if err != nil {
+		mu.Lock()
+		graph.Notes = append(graph.Notes, fmt.Sprintf("%s: SSH connection failed for discovery: %v", s.Name, err))
+		mu.Unlock()
+		return
+	}
+	out, _, err := client.RunCommandTimeout(fmt.Sprintf(nmapScript, cidr), nmapScanTimeout)
+	if err != nil {
+		mu.Lock()
+		graph.Notes = append(graph.Notes, fmt.Sprintf("%s: nmap discovery on %s failed: %v", s.Name, cidr, err))
+		mu.Unlock()
+		return
+	}
+	if strings.Contains(out, "__NMAP_NOT_FOUND__") {
+		mu.Lock()
+		graph.Notes = append(graph.Notes, fmt.Sprintf("%s: nmap is not installed — skipping discovery on %s", s.Name, cidr))
+		mu.Unlock()
+		return
+	}
+
+	_, ipnet, _ := net.ParseCIDR(cidr)
+	networkAddr := ipnet.IP.String()
+
+	hosts := parseNmapHosts(out)
+	selfID := fmt.Sprintf("server-%d", s.ID)
+	mu.Lock()
+	defer mu.Unlock()
+	for _, h := range hosts {
+		// The network address itself sometimes answers ARP on bridge
+		// networks (an artifact of the bridge interface, not a real host).
+		if known[h.IP] || h.IP == networkAddr {
+			continue
+		}
+		nodeID := "discovered-" + strings.ReplaceAll(h.IP, ".", "-")
+		if !seenDiscovered[nodeID] {
+			seenDiscovered[nodeID] = true
+			name := h.IP
+			if h.Hostname != "" {
+				name = h.Hostname
+			}
+			graph.Nodes = append(graph.Nodes, TopologyNode{
+				ID: nodeID, Kind: "discovered", Name: name, Host: h.IP,
+				Detail: h.MACVendor, Networks: []string{netID},
+			})
+		}
+		label := "nmap"
+		if h.MACVendor != "" {
+			label = "nmap · " + h.MACVendor
+		}
+		graph.Edges = append(graph.Edges, TopologyEdge{
+			Source: selfID, Target: nodeID, Kind: "discovered", Label: label,
+		})
+	}
+}
+
+type nmapHost struct {
+	IP        string
+	Hostname  string
+	MACVendor string
+}
+
+// parseNmapHosts reads `nmap -sn` output: repeating blocks of
+//
+//	Nmap scan report for 172.30.10.11
+//	Host is up (0.000060s latency).
+//	MAC Address: 02:42:AC:1E:0A:0B (Unknown)
+//
+// (or "Nmap scan report for <hostname> (<ip>)" when reverse DNS resolves).
+func parseNmapHosts(out string) []nmapHost {
+	var hosts []nmapHost
+	var cur *nmapHost
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "Nmap scan report for "):
+			rest := strings.TrimPrefix(line, "Nmap scan report for ")
+			h := nmapHost{}
+			if i := strings.LastIndex(rest, " ("); i >= 0 && strings.HasSuffix(rest, ")") {
+				h.Hostname = rest[:i]
+				h.IP = rest[i+2 : len(rest)-1]
+			} else {
+				h.IP = rest
+			}
+			if net.ParseIP(h.IP) == nil {
+				continue
+			}
+			hosts = append(hosts, h)
+			cur = &hosts[len(hosts)-1]
+		case cur != nil && strings.HasPrefix(line, "MAC Address: "):
+			rest := strings.TrimPrefix(line, "MAC Address: ")
+			if i := strings.Index(rest, "("); i >= 0 && strings.HasSuffix(rest, ")") {
+				cur.MACVendor = rest[i+1 : len(rest)-1]
+			}
+		}
+	}
+	return hosts
+}
+
+// ── Network segmentation ──
+
+var cgnatNet = mustCIDR("100.64.0.0/10")
+
+func mustCIDR(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+// buildNetworks derives the network segments and assigns every node its
+// membership. Segments come exclusively from real interface CIDRs read off
+// servers over SSH (live scan, or the cached result of the last one) — no
+// guessed subnets. Addresses no scanned interface covers land in explicit
+// unmapped/VPN/public/loopback buckets instead.
+func buildNetworks(graph *TopologyGraph, nodeIPs map[string][]net.IP, ifaceNets map[string][]*net.IPNet, scanTimes map[string]time.Time) {
+	nodeName := map[string]string{}
+	for _, n := range graph.Nodes {
+		nodeName[n.ID] = n.Name
+	}
+
+	// Deduplicate real segments across servers, remembering which servers
+	// reported them and when the freshest reading was taken.
+	type realNet struct {
+		ipnet   *net.IPNet
+		sources []string
+		latest  time.Time
+	}
+	realNets := map[string]*realNet{}
+	for nodeID, nets := range ifaceNets {
+		for _, n := range nets {
+			masked := &net.IPNet{IP: n.IP.Mask(n.Mask), Mask: n.Mask}
+			key := masked.String()
+			if realNets[key] == nil {
+				realNets[key] = &realNet{ipnet: masked}
+			}
+			src := nodeName[nodeID]
+			if src != "" && !slices.Contains(realNets[key].sources, src) {
+				realNets[key].sources = append(realNets[key].sources, src)
+			}
+			if t := scanTimes[nodeID]; t.After(realNets[key].latest) {
+				realNets[key].latest = t
+			}
+		}
+	}
+
+	networks := map[string]*TopologyNetwork{}
+	addNetwork := func(nw TopologyNetwork) string {
+		if existing, ok := networks[nw.ID]; ok {
+			return existing.ID
+		}
+		networks[nw.ID] = &nw
+		return nw.ID
+	}
+
+	realKeys := make([]string, 0, len(realNets))
+	for key := range realNets {
+		realKeys = append(realKeys, key)
+	}
+	sort.Strings(realKeys)
+	for _, key := range realKeys {
+		rn := realNets[key]
+		source := "interfaces on " + strings.Join(rn.sources, ", ")
+		if !rn.latest.IsZero() {
+			source += " · scanned " + rn.latest.Local().Format("Jan 2 15:04")
+		}
+		addNetwork(TopologyNetwork{
+			ID:     "net-" + key,
+			CIDR:   key,
+			Label:  key,
+			Kind:   classifyIP(rn.ipnet.IP),
+			Source: source,
+		})
+	}
+
+	// networkFor buckets one address, creating the segment if it's new.
+	networkFor := func(ip net.IP) string {
+		for _, key := range realKeys {
+			if realNets[key].ipnet.Contains(ip) {
+				return "net-" + key
+			}
+		}
+		switch {
+		case ip.IsLoopback():
+			return addNetwork(TopologyNetwork{ID: "net-loopback", CIDR: "127.0.0.0/8", Label: "loopback", Kind: "loopback"})
+		case ip.To4() != nil && cgnatNet.Contains(ip):
+			return addNetwork(TopologyNetwork{ID: "net-cgnat", CIDR: cgnatNet.String(), Label: "100.64.0.0/10 · CGNAT / VPN", Kind: "vpn"})
+		case ip.IsPrivate():
+			return addNetwork(TopologyNetwork{
+				ID: "net-unmapped-private", CIDR: "", Label: "private · unmapped", Kind: "private",
+				Source: "no scanned server interface covers these addresses — run a live scan",
+			})
+		default:
+			return addNetwork(TopologyNetwork{ID: "net-public", CIDR: "0.0.0.0/0", Label: "public / internet", Kind: "public"})
+		}
+	}
+
+	// Membership: real scanned interfaces are ground truth and go first (the
+	// primary placement/color on the map), since the declared "host" a server
+	// is reached at is often not where it actually sits — port-forwards,
+	// jump hosts, NAT, and localhost-mapped test/container setups all mean
+	// the SSH target address can differ from the machine's real network.
+	// Declared/resolved addresses only fill in when no scan has run yet.
+	for i := range graph.Nodes {
+		node := &graph.Nodes[i]
+		seen := map[string]bool{}
+		add := func(id string) {
+			if id != "" && !seen[id] {
+				seen[id] = true
+				node.Networks = append(node.Networks, id)
+			}
+		}
+		for _, n := range ifaceNets[node.ID] {
+			masked := &net.IPNet{IP: n.IP.Mask(n.Mask), Mask: n.Mask}
+			add("net-" + masked.String())
+		}
+		if ip := net.ParseIP(node.Host); ip != nil {
+			add(networkFor(ip))
+		}
+		for _, ip := range nodeIPs[node.ID] {
+			add(networkFor(ip))
+		}
+	}
+
+	// Stable ordering: real private segments first, then unmapped, VPN,
+	// public, loopback — the same order the frontend lays zones out in.
+	kindRank := map[string]int{"private": 0, "vpn": 1, "public": 2, "loopback": 3}
+	list := make([]TopologyNetwork, 0, len(networks))
+	for _, nw := range networks {
+		list = append(list, *nw)
+	}
+	sort.Slice(list, func(i, j int) bool {
+		ri, rj := kindRank[list[i].Kind], kindRank[list[j].Kind]
+		if ri != rj {
+			return ri < rj
+		}
+		iUnmapped := list[i].ID == "net-unmapped-private"
+		jUnmapped := list[j].ID == "net-unmapped-private"
+		if iUnmapped != jUnmapped {
+			return jUnmapped
+		}
+		return list[i].CIDR < list[j].CIDR
+	})
+	graph.Networks = list
+}
+
+func classifyIP(ip net.IP) string {
+	switch {
+	case ip.IsLoopback():
+		return "loopback"
+	case cgnatNet.Contains(ip):
+		return "vpn"
+	case ip.IsPrivate():
+		return "private"
+	default:
+		return "public"
+	}
+}
+
+// parseIfaceNets reads interface-script output: "10.0.0.11/24" (linux,
+// windows) or "10.0.0.11 0xffffff00" (macOS hex netmask).
+// ifaceAddr is one scanned interface address: its exact IP (for identifying
+// the scanning server itself in discovery results) plus the masked network
+// it belongs to (the real, no-guessing subnet used for zoning the map).
+type ifaceAddr struct {
+	IP  net.IP
+	Net *net.IPNet
+}
+
+func parseIfaceNets(out string) []ifaceAddr {
+	addrs := []ifaceAddr{}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ip net.IP
+		var mask net.IPMask
+		if strings.Contains(line, "/") {
+			parsedIP, n, err := net.ParseCIDR(line)
+			if err != nil || parsedIP.To4() == nil {
+				continue
+			}
+			ip, mask = parsedIP, n.Mask
+		} else if fields := strings.Fields(line); len(fields) == 2 {
+			parsedIP := net.ParseIP(fields[0])
+			var maskBits uint32
+			if _, err := fmt.Sscanf(fields[1], "0x%x", &maskBits); err != nil || parsedIP == nil || parsedIP.To4() == nil {
+				continue
+			}
+			ip = parsedIP
+			mask = net.IPv4Mask(byte(maskBits>>24), byte(maskBits>>16), byte(maskBits>>8), byte(maskBits))
+		} else {
+			continue
+		}
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+			continue
+		}
+		addrs = append(addrs, ifaceAddr{IP: ip, Net: &net.IPNet{IP: ip.Mask(mask), Mask: mask}})
+	}
+	return addrs
+}
+
+// splitRemoteAddr parses "10.0.0.5:5432", "[::1]:80", and the macOS netstat
+// form "10.0.0.5.5432" into address and port.
+func splitRemoteAddr(addr string) (string, string) {
+	if addr == "" || addr == "*" {
+		return "", ""
+	}
+	if host, port, err := net.SplitHostPort(addr); err == nil {
+		return host, port
+	}
+	// macOS netstat separates the port with a dot.
+	if i := strings.LastIndex(addr, "."); i > 0 && !strings.Contains(addr, ":") {
+		return addr[:i], addr[i+1:]
+	}
+	return "", ""
+}
+
+func splitTags(tags string) []string {
+	out := []string{}
+	for _, t := range strings.Split(tags, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/backend/internal/httpapi/routes.go
+++ b/backend/internal/httpapi/routes.go
@@ -48,6 +48,11 @@ func RegisterRoutes(r *gin.Engine) {
 		api.PUT("/folders/:id", middleware.RequireRole("admin", "devops"), handlers.UpdateFolder)
 		api.DELETE("/folders/:id", middleware.RequireRole("admin", "devops"), handlers.DeleteFolder)
 
+		// ── Infrastructure blueprint (topology map) ───────────────
+		// Visible to every authenticated role; the handler filters servers
+		// by per-user access grants and resources by role internally.
+		api.GET("/topology", handlers.GetTopology)
+
 		// ── Servers ───────────────────────────────────────────────
 		api.GET("/servers", handlers.ListServers)
 		api.POST("/servers", middleware.RequireRole("admin", "devops"), handlers.CreateServer)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -160,6 +160,17 @@ type ResourceMetric struct {
 	Metrics    string    `gorm:"type:text" json:"metrics"` // JSON: type-specific gauges
 }
 
+// NetworkScan caches the most recent set of real interface CIDRs read from a
+// server over SSH (topology live scan). Follows the SecurityScan precedent:
+// scans always run live on request, only the latest outcome is kept so the
+// infrastructure map can show real network segments — never guessed ones —
+// without forcing an SSH sweep on every page load.
+type NetworkScan struct {
+	ServerID  uint      `gorm:"primaryKey;autoIncrement:false" json:"server_id"`
+	CIDRs     string    `gorm:"column:cidrs;type:text" json:"cidrs"` // JSON array, e.g. ["10.0.0.0/24","172.17.0.0/16"]
+	ScannedAt time.Time `json:"scanned_at"`
+}
+
 type Metric struct {
 	ID          uint      `gorm:"primaryKey" json:"id"`
 	ServerID    uint      `gorm:"index;not null" json:"server_id"`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.6",
+  "version": "1.6.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { AuditHardening } from './pages/AuditHardening'
 import { AuditCluster } from './pages/AuditCluster'
 import { AuditResources } from './pages/AuditResources'
 import { IacSync } from './pages/IacSync'
+import { InfraMap } from './pages/InfraMap'
 import { useAuthStore } from './store/authStore'
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
@@ -37,6 +38,7 @@ export default function App() {
           <Route path="servers" element={<Servers />} />
           <Route path="servers/:id" element={<ServerDetail />} />
           <Route path="servers/:id/networking" element={<Networking />} />
+          <Route path="infra-map" element={<InfraMap />} />
           <Route path="resources" element={<Resources />} />
           <Route path="resources/:id" element={<ResourceDetail />} />
           <Route path="logs" element={<Navigate to="/" />} /> {/* Redirects to select a server */}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@ import {
   LayoutDashboard, Server, Boxes,
   Bot, Bell, Settings, LogOut, ChevronRight,
   ChevronLeft, Menu, Code2, Sun, Moon, ChevronDown, Shield, Database, X,
-  ShieldAlert, Lock, Network, KeyRound, GitBranch, Download, Workflow
+  ShieldAlert, Lock, Network, KeyRound, GitBranch, Download, Workflow, Map
 } from 'lucide-react'
 import { useAuthStore } from '../../store/authStore'
 import { useUIStore } from '../../store/uiStore'
@@ -33,6 +33,7 @@ const navGroups: { label: string; items: NavItem[] }[] = [
   {
     label: 'Infrastructure',
     items: [
+      { to: '/infra-map',  icon: Map,             label: 'Infra Map' },
       { to: '/kubernetes', icon: KubernetesIcon,  label: 'Kubernetes',  action: 'use-kubectl' },
       { to: '/resources',  icon: Database,        label: 'Resources',   action: 'manage-resources' },
       { to: '/alerts',     icon: Bell,            label: 'Alert Rules', action: 'view-alerts' },

--- a/frontend/src/pages/InfraMap.tsx
+++ b/frontend/src/pages/InfraMap.tsx
@@ -1,0 +1,872 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  Server, Boxes, Database, Zap, Layers, HardDrive, Globe, Cpu, Eye,
+  Download, RefreshCw, Radar, ZoomIn, ZoomOut, Maximize, Loader2, AlertTriangle,
+  Network, Folder, ScanSearch, Wifi,
+} from 'lucide-react'
+import { api } from '../api/client'
+import { useUIStore } from '../store/uiStore'
+import { useToastStore } from '../store/toastStore'
+import { Button } from '../components/ui'
+
+// ── Topology API shapes (mirror backend handlers/topology.go) ──
+
+interface TNode {
+  id: string
+  kind: 'core' | 'server' | 'cluster' | 'resource' | 'k8s_node' | 'discovered'
+  ref_id?: number
+  name: string
+  host?: string
+  port?: number
+  status?: string
+  os?: string
+  resource_type?: string
+  protocol?: string
+  folder_id?: number | null
+  tags?: string[]
+  detail?: string
+  networks?: string[]
+}
+
+interface TEdge {
+  source: string
+  target: string
+  kind: 'manage' | 'hosted_on' | 'network' | 'member' | 'discovered'
+  label?: string
+}
+
+interface TFolder { id: number; name: string; color?: string }
+
+interface TNetwork {
+  id: string
+  cidr: string
+  label: string
+  kind: 'private' | 'vpn' | 'public' | 'loopback'
+  source?: string
+}
+
+interface Topology {
+  generated_at: string
+  live: boolean
+  folders: TFolder[]
+  networks: TNetwork[]
+  nodes: TNode[]
+  edges: TEdge[]
+  notes?: string[]
+}
+
+type GroupMode = 'network' | 'folder'
+
+// ── Layout geometry ──
+
+interface Box { x: number; y: number; w: number; h: number }
+interface GroupBox extends Box { label: string; color: string }
+
+const SIZE: Record<TNode['kind'], { w: number; h: number }> = {
+  core: { w: 230, h: 76 },
+  server: { w: 230, h: 66 },
+  cluster: { w: 230, h: 66 },
+  resource: { w: 210, h: 60 },
+  k8s_node: { w: 200, h: 50 },
+  discovered: { w: 210, h: 50 },
+}
+
+const NODE_GAP = 16
+const GROUP_PAD = 14
+const GROUP_HEADER = 26
+const GROUP_GAP = 34
+const COL_X = [56, 470, 900]
+const TOP_MARGIN = 96 // leaves room for the title block
+const BOTTOM_MARGIN = 48
+
+function resourceIcon(type?: string) {
+  switch (type) {
+    case 'database': return Database
+    case 'cache': return Zap
+    case 'queue': return Layers
+    case 'storage': return HardDrive
+    case 'service': return Globe
+    default: return Cpu
+  }
+}
+
+function nodeIcon(n: TNode) {
+  switch (n.kind) {
+    case 'core': return Eye
+    case 'server': return Server
+    case 'cluster': return Boxes
+    case 'k8s_node': return Cpu
+    case 'discovered': return Wifi
+    case 'resource': return resourceIcon(n.resource_type)
+  }
+}
+
+// The map is drawn with literal colors (not var() references) so the SVG can
+// be exported as a standalone file. Colors are resolved from the CSS variables
+// on the root element.
+function readPalette() {
+  const cs = getComputedStyle(document.documentElement)
+  const v = (name: string, fb: string) => (cs.getPropertyValue(name) || '').trim() || fb
+  return {
+    bg: v('--bg-app', '#f0f0f0'),
+    card: v('--bg-card', '#ffffff'),
+    elevated: v('--bg-elevated', '#f5f5f5'),
+    border: v('--border', '#d2d2d2'),
+    borderLight: v('--border-light', '#ededed'),
+    text: v('--text-primary', '#151515'),
+    textSec: v('--text-secondary', '#6a6e73'),
+    textMuted: v('--text-muted', '#a2a3a4'),
+    brand: v('--brand-primary', '#0066cc'),
+    success: v('--success', '#3e8635'),
+    warning: v('--warning', '#f0ab00'),
+    danger: v('--danger', '#c9190b'),
+    info: v('--info', '#2b9af3'),
+    purple: v('--accent-purple', '#8b5cf6'),
+    cyan: v('--accent-cyan', '#06b6d4'),
+  }
+}
+
+function useCssPalette() {
+  const { darkMode } = useUIStore()
+  const [palette, setPalette] = useState(readPalette)
+  // useThemeSync flips the `dark` class on <html> in the parent Layout's
+  // effect, which runs AFTER this component's effects — so re-read the
+  // variables one frame later, once the class change has landed.
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => setPalette(readPalette()))
+    return () => cancelAnimationFrame(raf)
+  }, [darkMode])
+  return palette
+}
+
+function statusColor(status: string | undefined, p: ReturnType<typeof useCssPalette>) {
+  switch (status) {
+    case 'online': return p.success
+    case 'degraded': return p.warning
+    case 'offline': return p.danger
+    default: return p.textMuted
+  }
+}
+
+function edgeStyle(kind: TEdge['kind'], p: ReturnType<typeof useCssPalette>) {
+  switch (kind) {
+    case 'manage': return { stroke: p.brand, dash: undefined }
+    case 'hosted_on': return { stroke: p.purple, dash: undefined }
+    case 'network': return { stroke: p.cyan, dash: '6 4' }
+    case 'member': return { stroke: p.info, dash: '2 3' }
+    case 'discovered': return { stroke: p.textMuted, dash: '1 4' }
+  }
+}
+
+// Column layout: InfraEye core on the left, servers/clusters in the middle,
+// cluster nodes + resources on the right — a left-to-right "who manages /
+// hosts what" blueprint. Columns are grouped into zones either by folder or
+// by network segment; in network mode the same segment gets the same color
+// in both columns, so "these machines share a network" reads at a glance.
+function computeLayout(topo: Topology, mode: GroupMode, netColors: Record<string, string>) {
+  const pos: Record<string, Box> = {}
+  const groups: GroupBox[] = []
+
+  const folderName = (id?: number | null) =>
+    topo.folders.find(f => f.id === id)?.name ?? 'Ungrouped'
+  const folderColor = (id?: number | null, fb = '') =>
+    topo.folders.find(f => f.id === id)?.color || fb
+
+  const byFolder = (nodes: TNode[]) => {
+    const order: (number | null)[] = [
+      ...topo.folders.filter(f => nodes.some(n => n.folder_id === f.id)).map(f => f.id),
+      ...(nodes.some(n => !n.folder_id) ? [null] : []),
+    ]
+    return order.map(fid => ({
+      label: folderName(fid),
+      color: folderColor(fid),
+      nodes: nodes.filter(n => (n.folder_id ?? null) === (fid ?? null)),
+    }))
+  }
+
+  // Placement uses the node's primary (first) network; multi-homed machines
+  // list every segment in their tooltip.
+  const primaryNet = (n: TNode) => n.networks?.[0] ?? null
+  const byNetwork = (nodes: TNode[]) => {
+    const order: (string | null)[] = [
+      ...topo.networks.filter(nw => nodes.some(n => primaryNet(n) === nw.id)).map(nw => nw.id),
+      ...(nodes.some(n => !primaryNet(n)) ? [null] : []),
+    ]
+    return order.map(nid => {
+      const nw = topo.networks.find(x => x.id === nid)
+      return {
+        label: nw ? nw.label : 'no address / unresolved',
+        color: nid ? netColors[nid] ?? '' : '',
+        nodes: nodes.filter(n => primaryNet(n) === nid),
+      }
+    })
+  }
+
+  const groupBy = mode === 'network' ? byNetwork : byFolder
+
+  const layoutColumn = (colX: number, groupDefs: { label: string; color: string; nodes: TNode[] }[]) => {
+    let y = TOP_MARGIN
+    for (const g of groupDefs) {
+      if (g.nodes.length === 0) continue
+      const w = Math.max(...g.nodes.map(n => SIZE[n.kind].w))
+      const startY = y
+      y += GROUP_HEADER + GROUP_PAD
+      for (const n of g.nodes) {
+        pos[n.id] = { x: colX, y, w: SIZE[n.kind].w, h: SIZE[n.kind].h }
+        y += SIZE[n.kind].h + NODE_GAP
+      }
+      y += GROUP_PAD - NODE_GAP
+      groups.push({ x: colX - GROUP_PAD, y: startY, w: w + GROUP_PAD * 2, h: y - startY, label: g.label, color: g.color })
+      y += GROUP_GAP
+    }
+    return y - GROUP_GAP
+  }
+
+  const servers = topo.nodes.filter(n => n.kind === 'server' || n.kind === 'cluster')
+  const resources = topo.nodes.filter(n => n.kind === 'resource')
+  const k8sNodes = topo.nodes.filter(n => n.kind === 'k8s_node')
+  const discovered = topo.nodes.filter(n => n.kind === 'discovered')
+
+  const col1Bottom = layoutColumn(COL_X[1], groupBy(servers))
+
+  // Right column. Folder mode: each cluster's member nodes first, then
+  // resources (and any nmap-discovered peers) grouped by folder. Network
+  // mode: cluster nodes, resources and discovered peers are all zoned
+  // together by segment — a K8s node or an undiscovered device sharing a
+  // subnet with a database shows up in the same zone.
+  let col2Groups
+  if (mode === 'network') {
+    col2Groups = byNetwork([...k8sNodes, ...resources, ...discovered])
+  } else {
+    const clusterGroups = servers
+      .filter(s => s.kind === 'cluster')
+      .map(cl => ({
+        label: `${cl.name} · nodes`,
+        color: '',
+        nodes: k8sNodes.filter(n => n.ref_id === cl.ref_id),
+      }))
+      .filter(g => g.nodes.length > 0)
+    const discoveredGroup = discovered.length > 0
+      ? [{ label: 'discovered · unmanaged', color: '', nodes: discovered }]
+      : []
+    col2Groups = [...clusterGroups, ...byFolder(resources), ...discoveredGroup]
+  }
+  const col2Bottom = layoutColumn(COL_X[2], col2Groups)
+
+  const contentH = Math.max(col1Bottom, col2Bottom, TOP_MARGIN + 200) + BOTTOM_MARGIN
+
+  // Core node vertically centered on the server column.
+  const core = topo.nodes.find(n => n.kind === 'core')
+  if (core) {
+    const mid = Math.max(col1Bottom, TOP_MARGIN + 200) / 2 + TOP_MARGIN / 2
+    pos[core.id] = { x: COL_X[0], y: mid - SIZE.core.h / 2, w: SIZE.core.w, h: SIZE.core.h }
+  }
+
+  const contentW = COL_X[2] + Math.max(SIZE.resource.w, SIZE.k8s_node.w) + GROUP_PAD + 60
+  return { pos, groups, contentW, contentH }
+}
+
+function edgePath(s: Box, t: Box): { d: string; mid: [number, number] } {
+  const sr: [number, number] = [s.x + s.w, s.y + s.h / 2]
+  const sl: [number, number] = [s.x, s.y + s.h / 2]
+  const tr: [number, number] = [t.x + t.w, t.y + t.h / 2]
+  const tl: [number, number] = [t.x, t.y + t.h / 2]
+
+  if (t.x >= s.x + s.w) {
+    const dx = (tl[0] - sr[0]) / 2
+    return {
+      d: `M ${sr[0]} ${sr[1]} C ${sr[0] + dx} ${sr[1]}, ${tl[0] - dx} ${tl[1]}, ${tl[0]} ${tl[1]}`,
+      mid: [(sr[0] + tl[0]) / 2, (sr[1] + tl[1]) / 2 - 6],
+    }
+  }
+  if (s.x >= t.x + t.w) {
+    const dx = (sl[0] - tr[0]) / 2
+    return {
+      d: `M ${sl[0]} ${sl[1]} C ${sl[0] - dx} ${sl[1]}, ${tr[0] + dx} ${tr[1]}, ${tr[0]} ${tr[1]}`,
+      mid: [(sl[0] + tr[0]) / 2, (sl[1] + tr[1]) / 2 - 6],
+    }
+  }
+  // Same column (e.g. observed server↔server traffic): bulge out to the right.
+  const bulge = 70 + Math.abs(tr[1] - sr[1]) * 0.08
+  return {
+    d: `M ${sr[0]} ${sr[1]} C ${sr[0] + bulge} ${sr[1]}, ${tr[0] + bulge} ${tr[1]}, ${tr[0]} ${tr[1]}`,
+    mid: [sr[0] + bulge * 0.75, (sr[1] + tr[1]) / 2],
+  }
+}
+
+function saveBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export function InfraMap() {
+  const navigate = useNavigate()
+  const toast = useToastStore()
+  const p = useCssPalette()
+
+  const [topo, setTopo] = useState<Topology | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [scanning, setScanning] = useState(false)
+  const [liveMode, setLiveMode] = useState(false)
+  const [discoverMode, setDiscoverMode] = useState(false)
+  const [error, setError] = useState('')
+  const [hoverId, setHoverId] = useState<string | null>(null)
+  const [notesOpen, setNotesOpen] = useState(false)
+  const [groupMode, setGroupMode] = useState<GroupMode>('network')
+  const [view, setView] = useState({ x: 0, y: 0, k: 1 })
+
+  const svgRef = useRef<SVGSVGElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<{ startX: number; startY: number; viewX: number; viewY: number } | null>(null)
+
+  // One stable color per network segment, cycled from the accent palette.
+  const netColors = useMemo(() => {
+    const cycle = [p.brand, p.purple, p.cyan, p.success, p.warning, p.info, p.danger]
+    const map: Record<string, string> = {}
+    topo?.networks?.forEach((nw, i) => { map[nw.id] = cycle[i % cycle.length] })
+    return map
+  }, [topo, p])
+
+  const layout = useMemo(
+    () => (topo ? computeLayout(topo, groupMode, netColors) : null),
+    [topo, groupMode, netColors],
+  )
+
+  const neighbors = useMemo(() => {
+    const map: Record<string, Set<string>> = {}
+    for (const e of topo?.edges ?? []) {
+      ;(map[e.source] ??= new Set()).add(e.target)
+      ;(map[e.target] ??= new Set()).add(e.source)
+    }
+    return map
+  }, [topo])
+
+  const fetchTopology = useCallback(async (live: boolean, discover: boolean) => {
+    if (live) setScanning(true)
+    else setLoading(true)
+    setError('')
+    try {
+      const params = live ? `?live=true${discover ? '&discover=true' : ''}` : ''
+      const res = await api.get(`/api/topology${params}`)
+      setTopo(res.data)
+    } catch (e) {
+      const err = e as { response?: { data?: { error?: string } }; message?: string }
+      setError(err.response?.data?.error || err.message || 'Failed to load topology')
+    } finally {
+      setLoading(false)
+      setScanning(false)
+    }
+  }, [])
+
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, matches every other page
+  useEffect(() => { fetchTopology(false, false) }, [fetchTopology])
+
+  const fitView = useCallback(() => {
+    if (!layout || !containerRef.current) return
+    const { clientWidth: cw, clientHeight: ch } = containerRef.current
+    const k = Math.min(cw / layout.contentW, ch / layout.contentH, 1.15)
+    setView({
+      x: (cw - layout.contentW * k) / 2,
+      y: Math.max((ch - layout.contentH * k) / 2, 8),
+      k,
+    })
+  }, [layout])
+
+  // Fit whenever the graph's shape changes (first load, live scan adds nodes).
+  useEffect(() => { fitView() }, [fitView])
+
+  // Native wheel listener: React's onWheel is passive, so preventDefault (to
+  // stop the page scrolling while zooming the map) needs a manual binding.
+  // Depends on loading/error because the canvas div only exists once the
+  // topology has loaded — binding on mount would grab nothing.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const onWheel = (ev: WheelEvent) => {
+      ev.preventDefault()
+      const rect = el.getBoundingClientRect()
+      const mx = ev.clientX - rect.left
+      const my = ev.clientY - rect.top
+      // Trackpad pinch arrives as ctrl+wheel with fine deltas; plain
+      // two-finger scroll and mouse wheels zoom too, maps-style, always
+      // centered on the pointer.
+      const factor = Math.exp(-ev.deltaY * (ev.ctrlKey || ev.metaKey ? 0.012 : 0.0022))
+      setView(v => {
+        const k = Math.min(3, Math.max(0.15, v.k * factor))
+        return { k, x: mx - ((mx - v.x) / v.k) * k, y: my - ((my - v.y) / v.k) * k }
+      })
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [loading, error])
+
+  const [dragging, setDragging] = useState(false)
+  const onMouseDown = (e: React.MouseEvent) => {
+    dragRef.current = { startX: e.clientX, startY: e.clientY, viewX: view.x, viewY: view.y }
+    setDragging(true)
+  }
+  const onMouseMove = (e: React.MouseEvent) => {
+    const d = dragRef.current
+    if (!d) return
+    setView(v => ({ ...v, x: d.viewX + (e.clientX - d.startX), y: d.viewY + (e.clientY - d.startY) }))
+  }
+  const onMouseUp = () => { dragRef.current = null; setDragging(false) }
+
+  const zoomBy = (factor: number) => {
+    const el = containerRef.current
+    if (!el) return
+    const cx = el.clientWidth / 2
+    const cy = el.clientHeight / 2
+    setView(v => {
+      const k = Math.min(3, Math.max(0.15, v.k * factor))
+      return { k, x: cx - ((cx - v.x) / v.k) * k, y: cy - ((cy - v.y) / v.k) * k }
+    })
+  }
+
+  const openNode = (n: TNode) => {
+    switch (n.kind) {
+      case 'server': navigate(`/servers/${n.ref_id}`); break
+      case 'cluster': case 'k8s_node': navigate('/kubernetes'); break
+      case 'resource': navigate(`/resources/${n.ref_id}`); break
+    }
+  }
+
+  // ── Export ──
+
+  const buildSvgString = () => {
+    if (!svgRef.current || !layout) return ''
+    const clone = svgRef.current.cloneNode(true) as SVGSVGElement
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+    clone.setAttribute('width', String(layout.contentW))
+    clone.setAttribute('height', String(layout.contentH))
+    clone.setAttribute('viewBox', `0 0 ${layout.contentW} ${layout.contentH}`)
+    const vp = clone.querySelector('#inframap-viewport')
+    vp?.setAttribute('transform', '')
+    return new XMLSerializer().serializeToString(clone)
+  }
+
+  const stamp = () => new Date().toISOString().slice(0, 10)
+
+  const downloadSvg = () => {
+    const s = buildSvgString()
+    if (!s) return
+    saveBlob(new Blob([s], { type: 'image/svg+xml;charset=utf-8' }), `infraeye-blueprint-${stamp()}.svg`)
+  }
+
+  const downloadPng = () => {
+    const s = buildSvgString()
+    if (!s || !layout) return
+    const url = URL.createObjectURL(new Blob([s], { type: 'image/svg+xml;charset=utf-8' }))
+    const img = new Image()
+    img.onload = () => {
+      const scale = 2
+      const canvas = document.createElement('canvas')
+      canvas.width = layout.contentW * scale
+      canvas.height = layout.contentH * scale
+      const ctx = canvas.getContext('2d')!
+      ctx.scale(scale, scale)
+      ctx.drawImage(img, 0, 0)
+      URL.revokeObjectURL(url)
+      canvas.toBlob(b => b && saveBlob(b, `infraeye-blueprint-${stamp()}.png`), 'image/png')
+    }
+    img.onerror = () => {
+      URL.revokeObjectURL(url)
+      toast.error('Export failed', 'Could not rasterize the blueprint — try the SVG export instead.')
+    }
+    img.src = url
+  }
+
+  const downloadJson = () => {
+    if (!topo) return
+    saveBlob(
+      new Blob([JSON.stringify(topo, null, 2)], { type: 'application/json' }),
+      `infraeye-blueprint-${stamp()}.json`,
+    )
+  }
+
+  // ── Render ──
+
+  if (loading) {
+    return (
+      <div className="page" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Loader2 size={28} className="spinner" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="page">
+        <div className="empty-state">
+          <AlertTriangle size={28} />
+          <p>{error}</p>
+          <Button variant="secondary" onClick={() => fetchTopology(liveMode, discoverMode)}>Retry</Button>
+        </div>
+      </div>
+    )
+  }
+
+  const nodes = topo?.nodes ?? []
+  const edges = topo?.edges ?? []
+  const netLabel = (id: string) => topo?.networks.find(nw => nw.id === id)?.label ?? id
+  const hasInfra = nodes.some(n => n.kind !== 'core')
+  const connectedTo = (id: string) => hoverId === id || (hoverId != null && (neighbors[hoverId]?.has(id) ?? false))
+  const serverCount = nodes.filter(n => n.kind === 'server').length
+  const clusterCount = nodes.filter(n => n.kind === 'cluster').length
+  const resourceCount = nodes.filter(n => n.kind === 'resource').length
+  const discoveredCount = nodes.filter(n => n.kind === 'discovered').length
+
+  return (
+    <div className="page" style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', paddingBottom: 0 }}>
+      {/* Header — kept to a single compact row so the canvas gets the page */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', marginBottom: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, minWidth: 0 }}>
+          <h1 className="page-title" style={{ fontSize: 22, margin: 0 }}>Infra Map</h1>
+          <p style={{ color: 'var(--text-secondary)', fontSize: 'var(--text-xs)', margin: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            servers, clusters, resources & the networks that join them
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', border: '1px solid var(--border)', borderRadius: 8, overflow: 'hidden' }}>
+            <Button
+              variant={groupMode === 'network' ? 'primary' : 'ghost'}
+              size="sm"
+              onClick={() => setGroupMode('network')}
+              title="Zone machines by the network segment they sit on"
+            >
+              <Network size={14} /> Networks
+            </Button>
+            <Button
+              variant={groupMode === 'folder' ? 'primary' : 'ghost'}
+              size="sm"
+              onClick={() => setGroupMode('folder')}
+              title="Zone machines by their InfraEye folder"
+            >
+              <Folder size={14} /> Folders
+            </Button>
+          </div>
+          <Button
+            variant={liveMode ? 'primary' : 'secondary'}
+            size="sm"
+            onClick={() => {
+              const next = !liveMode
+              setLiveMode(next)
+              if (!next) setDiscoverMode(false)
+              fetchTopology(next, next && discoverMode)
+            }}
+            disabled={scanning}
+            title="SSH into each server to map live TCP connections and enumerate cluster nodes"
+          >
+            {scanning ? <Loader2 size={14} className="spinner" /> : <Radar size={14} />}
+            {scanning ? 'Scanning…' : liveMode ? 'Live scan: on' : 'Live scan'}
+          </Button>
+          <Button
+            variant={discoverMode ? 'primary' : 'secondary'}
+            size="sm"
+            disabled={scanning || !liveMode}
+            onClick={() => {
+              const next = !discoverMode
+              setDiscoverMode(next)
+              if (next) toast.info('Discovering network…', 'Running an nmap ping sweep on each real segment — this actively probes your network.')
+              fetchTopology(true, next)
+            }}
+            title={liveMode ? 'Ping-sweep each real network segment with nmap to find devices InfraEye doesn\'t manage' : 'Turn on Live scan first'}
+          >
+            <ScanSearch size={14} /> {discoverMode ? 'Discover: on' : 'Discover'}
+          </Button>
+          <Button variant="secondary" size="sm" onClick={() => fetchTopology(liveMode, discoverMode)} disabled={scanning} title="Refresh">
+            <RefreshCw size={14} />
+          </Button>
+          <Button variant="secondary" size="sm" onClick={downloadPng} title="Download blueprint as PNG image">
+            <Download size={14} /> PNG
+          </Button>
+          <Button variant="secondary" size="sm" onClick={downloadSvg} title="Download blueprint as SVG vector">
+            <Download size={14} /> SVG
+          </Button>
+          <Button variant="secondary" size="sm" onClick={downloadJson} title="Download raw topology as JSON">
+            <Download size={14} /> JSON
+          </Button>
+          {(topo?.notes?.length ?? 0) > 0 && (
+            <Button
+              variant="secondary" size="sm"
+              onClick={() => setNotesOpen(o => !o)}
+              style={{ borderColor: 'var(--warning)', color: 'var(--warning-dark)', position: 'relative' }}
+              title="Scan issues"
+            >
+              <AlertTriangle size={14} /> {topo!.notes!.length} issue{topo!.notes!.length > 1 ? 's' : ''}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <div
+        ref={containerRef}
+        style={{
+          position: 'relative', flex: 1, minHeight: 0, borderRadius: 10, overflow: 'hidden',
+          border: '1px solid var(--border)', background: 'var(--bg-app)',
+          cursor: dragging ? 'grabbing' : 'grab',
+        }}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onMouseLeave={onMouseUp}
+      >
+        {!hasInfra ? (
+          <div className="empty-state" style={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+            <Server size={28} />
+            <p>No infrastructure yet — add servers, clusters or resources to see the blueprint.</p>
+          </div>
+        ) : layout && (
+          <svg
+            ref={svgRef}
+            width="100%"
+            height="100%"
+            style={{ display: 'block', fontFamily: "'Inter Variable', Inter, sans-serif", userSelect: 'none' }}
+          >
+            <defs>
+              <pattern id="inframap-grid" width={40} height={40} patternUnits="userSpaceOnUse">
+                <path d="M 40 0 L 0 0 0 40" fill="none" stroke={p.borderLight} strokeWidth={1} opacity={0.6} />
+              </pattern>
+            </defs>
+            {/* Full-bleed grid: fixed to the viewport, not the content, so
+                panning/zooming never runs out of grid at the edges. */}
+            <rect width="100%" height="100%" fill={p.bg} />
+            <rect width="100%" height="100%" fill="url(#inframap-grid)" />
+            <g id="inframap-viewport" transform={`translate(${view.x},${view.y}) scale(${view.k})`}>
+
+              {/* Title block */}
+              <g>
+                <text x={COL_X[0]} y={34} fill={p.text} fontSize={17} fontWeight={800} letterSpacing={0.5}>
+                  INFRAEYE · INFRASTRUCTURE BLUEPRINT
+                </text>
+                <text x={COL_X[0]} y={54} fill={p.textSec} fontSize={11} fontFamily="'JetBrains Mono Variable', monospace">
+                  {serverCount} servers · {clusterCount} clusters · {resourceCount} resources
+                  {(topo?.networks?.length ?? 0) > 0 && ` · ${topo!.networks.length} network segments`}
+                  {discoveredCount > 0 && ` · ${discoveredCount} discovered`}
+                  {` · zoned by ${groupMode === 'network' ? 'network segment' : 'folder'}`}
+                  {topo && ` · generated ${new Date(topo.generated_at).toLocaleString()}`}
+                  {topo?.live ? ' · live network scan' : ''}
+                  {topo?.live && discoverMode ? ' + nmap discovery' : ''}
+                </text>
+                <line x1={COL_X[0]} y1={64} x2={layout.contentW - 60} y2={64} stroke={p.border} strokeWidth={1} />
+              </g>
+
+              {/* Folder / cluster group frames */}
+              {layout.groups.map((g, i) => (
+                <g key={i} opacity={hoverId ? 0.55 : 1}>
+                  <rect x={g.x} y={g.y} width={g.w} height={g.h} rx={10}
+                    fill={g.color || 'none'} fillOpacity={0.05}
+                    stroke={g.color || p.border} strokeWidth={1.2} strokeDasharray="5 4" opacity={0.8} />
+                  <text x={g.x + 10} y={g.y + 17} fill={g.color || p.textSec} fontSize={10.5} fontWeight={700} letterSpacing={0.8}>
+                    {g.label.toUpperCase()}
+                  </text>
+                </g>
+              ))}
+
+              {/* Edges */}
+              {edges.map((e, i) => {
+                const s = layout.pos[e.source]
+                const t = layout.pos[e.target]
+                if (!s || !t) return null
+                const st = edgeStyle(e.kind, p)
+                const { d, mid } = edgePath(s, t)
+                const active = hoverId != null && (e.source === hoverId || e.target === hoverId)
+                const dim = hoverId != null && !active
+                return (
+                  <g key={i} opacity={dim ? 0.12 : active ? 1 : 0.6}>
+                    <path d={d} fill="none" stroke={st.stroke} strokeWidth={active ? 2.2 : 1.4} strokeDasharray={st.dash}>
+                      <title>{`${e.kind}${e.label ? ` — ${e.label}` : ''}`}</title>
+                    </path>
+                    {e.label && active && (
+                      <text x={mid[0]} y={mid[1]} fill={st.stroke} fontSize={10} textAnchor="middle"
+                        fontFamily="'JetBrains Mono Variable', monospace" fontWeight={600}>
+                        {e.label}
+                      </text>
+                    )}
+                  </g>
+                )
+              })}
+
+              {/* Nodes */}
+              {nodes.map(n => {
+                const b = layout.pos[n.id]
+                if (!b) return null
+                const Icon = nodeIcon(n)
+                const sc = statusColor(n.status, p)
+                const isCore = n.kind === 'core'
+                const isDiscovered = n.kind === 'discovered'
+                const dim = hoverId != null && !connectedTo(n.id)
+                const sub = isCore
+                  ? 'control plane'
+                  : isDiscovered
+                    ? 'not managed by InfraEye'
+                    : n.kind === 'resource'
+                      ? `${n.protocol ?? n.resource_type ?? ''}${n.host ? ` · ${n.host}${n.port ? ':' + n.port : ''}` : ''}`
+                      : n.detail || (n.host ? `${n.host}${n.port ? ':' + n.port : ''}` : n.kind === 'cluster' ? 'kubernetes cluster' : '')
+                return (
+                  <g
+                    key={n.id}
+                    opacity={(dim ? 0.3 : 1) * (isDiscovered ? 0.85 : 1)}
+                    style={{ cursor: isCore || isDiscovered ? 'default' : 'pointer', transition: 'opacity 120ms' }}
+                    onMouseEnter={() => setHoverId(n.id)}
+                    onMouseLeave={() => setHoverId(null)}
+                    onClick={ev => { ev.stopPropagation(); openNode(n) }}
+                    onMouseDown={ev => ev.stopPropagation()}
+                  >
+                    <title>
+                      {[
+                        n.name,
+                        n.host && `${n.host}${n.port ? ':' + n.port : ''}`,
+                        isDiscovered && 'found by nmap discovery scan — not a managed InfraEye node',
+                        n.networks?.length ? `networks: ${n.networks.map(netLabel).join(', ')}` : null,
+                      ].filter(Boolean).join('\n')}
+                    </title>
+                    <rect x={b.x} y={b.y} width={b.w} height={b.h} rx={9}
+                      fill={isCore ? p.brand : p.card}
+                      stroke={hoverId === n.id ? p.brand : isCore ? p.brand : p.border}
+                      strokeWidth={hoverId === n.id ? 1.8 : 1.2}
+                      strokeDasharray={isDiscovered ? '4 3' : undefined} />
+                    {!isCore && (
+                      <rect x={b.x} y={b.y + 9} width={3.5} height={b.h - 18} rx={1.75} fill={isDiscovered ? p.textMuted : sc} />
+                    )}
+                    <Icon x={b.x + 14} y={b.y + b.h / 2 - 10} size={20} color={isCore ? '#ffffff' : isDiscovered ? p.textMuted : p.textSec} strokeWidth={2} />
+                    <text x={b.x + 44} y={b.y + b.h / 2 - 3} fill={isCore ? '#ffffff' : isDiscovered ? p.textSec : p.text}
+                      fontSize={13} fontWeight={700}>
+                      {n.name.length > 22 ? n.name.slice(0, 21) + '…' : n.name}
+                    </text>
+                    {sub && (
+                      <text x={b.x + 44} y={b.y + b.h / 2 + 13} fill={isCore ? 'rgba(255,255,255,0.75)' : p.textSec}
+                        fontSize={10} fontFamily="'JetBrains Mono Variable', monospace">
+                        {sub.length > 26 ? sub.slice(0, 25) + '…' : sub}
+                      </text>
+                    )}
+                    {!isCore && !isDiscovered && n.status && (
+                      <circle cx={b.x + b.w - 14} cy={b.y + 14} r={4} fill={sc}>
+                        <title>{n.status}</title>
+                      </circle>
+                    )}
+                    {/* Multi-homed: one dot per additional network segment */}
+                    {(n.networks?.length ?? 0) > 1 && n.networks!.slice(1).map((nid, di) => (
+                      <circle key={nid} cx={b.x + b.w - 14 - (di + 1) * 10} cy={b.y + b.h - 11} r={3.5}
+                        fill={netColors[nid] ?? p.textMuted} stroke={p.card} strokeWidth={1}>
+                        <title>{`also on ${netLabel(nid)}`}</title>
+                      </circle>
+                    ))}
+                  </g>
+                )
+              })}
+
+              {/* Legend */}
+              <g transform={`translate(${COL_X[0]}, ${layout.contentH - 26})`}>
+                {([
+                  ['manage', 'managed by InfraEye'],
+                  ['hosted_on', 'hosted on'],
+                  ['network', 'observed connection'],
+                  ['member', 'cluster member'],
+                  ['discovered', 'nmap discovered'],
+                ] as [TEdge['kind'], string][]).map(([kind, label], i) => {
+                  const st = edgeStyle(kind, p)
+                  return (
+                    <g key={kind} transform={`translate(${i * 165}, 0)`}>
+                      <line x1={0} y1={0} x2={26} y2={0} stroke={st.stroke} strokeWidth={2} strokeDasharray={st.dash} />
+                      <text x={32} y={4} fill={p.textSec} fontSize={10.5}>{label}</text>
+                    </g>
+                  )
+                })}
+              </g>
+            </g>
+          </svg>
+        )}
+
+        {/* Network segment legend — only meaningful in Networks mode. Each
+            entry states plainly whether the subnet is a real, scanned
+            interface CIDR or just an unmapped bucket, so nothing here reads
+            as more precise than it is. */}
+        {groupMode === 'network' && (topo?.networks?.length ?? 0) > 0 && (
+          <div style={{
+            position: 'absolute', top: 12, left: 12, maxWidth: 300,
+            background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 10,
+            padding: '10px 12px', fontSize: 11, boxShadow: '0 4px 16px rgba(0,0,0,0.1)',
+          }}>
+            <div style={{ fontWeight: 700, color: 'var(--text-secondary)', letterSpacing: 0.4, marginBottom: 6, textTransform: 'uppercase', fontSize: 10 }}>
+              Network segments
+            </div>
+            {topo!.networks.map(nw => {
+              const real = nw.id !== 'net-unmapped-private' && !!nw.cidr
+              return (
+                <div key={nw.id} style={{ display: 'flex', alignItems: 'flex-start', gap: 7, marginBottom: 5 }} title={nw.source}>
+                  <span style={{
+                    width: 9, height: 9, borderRadius: 3, marginTop: 2, flexShrink: 0,
+                    background: netColors[nw.id] ?? 'var(--text-muted)',
+                  }} />
+                  <div style={{ minWidth: 0 }}>
+                    <div style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)', fontWeight: 600 }}>
+                      {nw.cidr || nw.label}
+                    </div>
+                    <div style={{ color: real ? 'var(--success)' : 'var(--text-muted)', fontSize: 10 }}>
+                      {real ? 'scanned via SSH' : nw.kind === 'vpn' ? 'CGNAT / VPN range' : nw.kind === 'public' ? 'public internet' : 'not yet scanned'}
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Scan issues panel — floats over the canvas instead of pushing it
+            down, so the map keeps the full page regardless of issue count. */}
+        {notesOpen && (topo?.notes?.length ?? 0) > 0 && (
+          <div style={{
+            position: 'absolute', top: 12, right: 12, maxWidth: 420, maxHeight: '60%', overflowY: 'auto',
+            border: '1px solid var(--warning)', background: 'var(--bg-card)', borderRadius: 10,
+            padding: '10px 14px', fontSize: 'var(--text-xs)', color: 'var(--text-primary)',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.18)', zIndex: 2,
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginBottom: 4 }}>
+              <strong style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <AlertTriangle size={13} color="var(--warning)" /> Live scan issues
+              </strong>
+              <button className="sidebar-toggle-btn" onClick={() => setNotesOpen(false)} title="Close">×</button>
+            </div>
+            <ul style={{ margin: '4px 0 0 20px', fontFamily: 'var(--font-mono)' }}>
+              {topo!.notes!.map((n, i) => <li key={i} style={{ marginBottom: 4 }}>{n}</li>)}
+            </ul>
+          </div>
+        )}
+
+        {/* Pan/zoom controls */}
+        {hasInfra && (
+          <div style={{
+            position: 'absolute', right: 12, bottom: 12, display: 'flex', flexDirection: 'column', gap: 4,
+            background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 8, padding: 4,
+          }}>
+            <button className="sidebar-toggle-btn" onClick={() => zoomBy(1.25)} title="Zoom in"><ZoomIn size={14} /></button>
+            <div style={{ textAlign: 'center', fontSize: 10, color: 'var(--text-muted)', fontFamily: 'var(--font-mono)', padding: '1px 0' }}>
+              {Math.round(view.k * 100)}%
+            </div>
+            <button className="sidebar-toggle-btn" onClick={() => zoomBy(0.8)} title="Zoom out"><ZoomOut size={14} /></button>
+            <button className="sidebar-toggle-btn" onClick={fitView} title="Fit to view"><Maximize size={14} /></button>
+          </div>
+        )}
+
+        {/* Pan/zoom hint */}
+        {hasInfra && (
+          <div style={{
+            position: 'absolute', left: 12, bottom: 12, display: 'flex', alignItems: 'center', gap: 6,
+            fontSize: 10, color: 'var(--text-muted)', fontFamily: 'var(--font-mono)',
+            background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 8, padding: '4px 8px',
+            pointerEvents: 'none', opacity: 0.75,
+          }}>
+            drag to pan · scroll or pinch to zoom
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,11 +17,11 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://127.0.0.1:8080',
+        target: process.env.VITE_PROXY_TARGET || 'http://127.0.0.1:8080',
         changeOrigin: true,
       },
       '/ws': {
-        target: 'http://127.0.0.1:8080',
+        target: process.env.VITE_PROXY_TARGET || 'http://127.0.0.1:8080',
         ws: true,
       },
     }


### PR DESCRIPTION
## Summary
- Adds an Infra Map page (new sidebar entry under Infrastructure): a zoomable/pannable blueprint of servers, clusters, and resources, exportable as PNG/SVG/JSON.
- GET /api/topology builds the graph from DB state; ?live=true additionally SSHes into each server for established TCP connections and real interface CIDRs, and lists each connected cluster's nodes.
- Network segments come only from real SSH-scanned interface CIDRs — no guessed subnets. Real segments persist to a new network_scans table. Unscanned addresses land in an explicit "unmapped" bucket.
- ?discover=true (requires live=true) ping-sweeps each real segment with nmap to surface devices InfraEye doesn't manage — capped at 1024 hosts/segment, honestly reports when nmap isn't installed.
- Bumps version to 1.6.7.

## Test plan
- go build / go vet clean
- tsc -b / eslint clean on touched files
- npm run build production build succeeds
- Verified live against real Docker SSH infrastructure: two real subnets, a genuinely multi-homed container, and an unregistered shadow device correctly discovered via nmap
- Verified in-browser: pan/zoom (mouse + trackpad), network/folder zoning, PNG/SVG/JSON export, live scan, discover toggle, light/dark themes

🤖 Generated with Claude Code