### PR TITLE
feat(agent): match Agent flow canvases to the Infra Map blueprint style

### DIFF
--- a/frontend/src/components/agent/AgentFlowCanvas.tsx
+++ b/frontend/src/components/agent/AgentFlowCanvas.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
-  ReactFlow, ReactFlowProvider, Background, Controls, BackgroundVariant,
-  useReactFlow, type Node, type Edge, type NodeTypes,
+  ReactFlow, ReactFlowProvider, useReactFlow, type Node, type Edge, type NodeTypes,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { GoalFlowNode, StepFlowNode, ThinkingFlowNode, nodeColor } from './AgentFlowNodes'
+import { FlowBlueprintBackground, FlowZoomControls, FlowPanHint } from './FlowChrome'
 import type { AgentRun } from '../../pages/agentTypes'
 
 const nodeTypes: NodeTypes = {
@@ -28,9 +28,12 @@ function FlowInner({ run, selectedStepId, onSelectStep, onApprove, onReject, bus
   const { fitView } = useReactFlow()
   const isRunning = run.status === 'running'
   const steps = run.steps ?? []
+  // Hovering a node dims everything not adjacent to it, matching the Infra
+  // Map blueprint's "highlight the connected chain" behavior.
+  const [hoverId, setHoverId] = useState<string | null>(null)
 
   const { nodes, edges } = useMemo(() => {
-    const nodes: Node[] = [
+    const rawNodes: Node[] = [
       {
         id: 'goal',
         type: 'goal',
@@ -40,21 +43,21 @@ function FlowInner({ run, selectedStepId, onSelectStep, onApprove, onReject, bus
         selectable: false,
       },
     ]
-    const edges: Edge[] = []
+    const rawEdges: Edge[] = []
     let prevId = 'goal'
     let prevColor = 'var(--brand-primary)'
 
     steps.forEach((step, i) => {
       const id = `step-${step.id}`
       const color = nodeColor(step)
-      nodes.push({
+      rawNodes.push({
         id,
         type: 'step',
         position: { x: (i + 1) * NODE_SPACING, y: 60 },
         data: { kind: 'step', step, selected: selectedStepId === step.id, isBusy: busyStepId === step.id, onApprove, onReject },
         draggable: false,
       })
-      edges.push({
+      rawEdges.push({
         id: `e-${prevId}-${id}`,
         source: prevId,
         target: id,
@@ -68,7 +71,7 @@ function FlowInner({ run, selectedStepId, onSelectStep, onApprove, onReject, bus
 
     if (isRunning) {
       const id = 'thinking'
-      nodes.push({
+      rawNodes.push({
         id,
         type: 'thinking',
         position: { x: (steps.length + 1) * NODE_SPACING, y: 66 },
@@ -76,7 +79,7 @@ function FlowInner({ run, selectedStepId, onSelectStep, onApprove, onReject, bus
         draggable: false,
         selectable: false,
       })
-      edges.push({
+      rawEdges.push({
         id: `e-${prevId}-${id}`,
         source: prevId,
         target: id,
@@ -86,8 +89,20 @@ function FlowInner({ run, selectedStepId, onSelectStep, onApprove, onReject, bus
       })
     }
 
+    if (!hoverId) return { nodes: rawNodes, edges: rawEdges }
+
+    const neighbors = new Set([hoverId])
+    for (const e of rawEdges) {
+      if (e.source === hoverId) neighbors.add(e.target)
+      if (e.target === hoverId) neighbors.add(e.source)
+    }
+    const nodes = rawNodes.map(n => ({ ...n, style: { ...n.style, opacity: neighbors.has(n.id) ? 1 : 0.3, transition: 'opacity 120ms' } }))
+    const edges = rawEdges.map(e => {
+      const active = e.source === hoverId || e.target === hoverId
+      return { ...e, style: { ...e.style, opacity: active ? 1 : 0.15 }, zIndex: active ? 1 : 0 }
+    })
     return { nodes, edges }
-  }, [run.goal, steps, isRunning, selectedStepId, busyStepId, onApprove, onReject])
+  }, [run.goal, steps, isRunning, selectedStepId, busyStepId, onApprove, onReject, hoverId])
 
   useEffect(() => {
     fitView({ padding: 0.25, duration: 400, maxZoom: 1 })
@@ -101,15 +116,17 @@ function FlowInner({ run, selectedStepId, onSelectStep, onApprove, onReject, bus
       onNodeClick={(_, node) => {
         if (node.type === 'step') onSelectStep(Number(node.id.replace('step-', '')))
       }}
+      onNodeMouseEnter={(_, node) => setHoverId(node.id)}
+      onNodeMouseLeave={() => setHoverId(null)}
       onPaneClick={() => onSelectStep(null)}
       proOptions={{ hideAttribution: true }}
-      minZoom={0.3}
-      maxZoom={1.5}
-      panOnScroll
+      minZoom={0.15}
+      maxZoom={3}
       fitView
     >
-      <Background variant={BackgroundVariant.Dots} gap={22} size={1.4} color="var(--border)" />
-      <Controls showInteractive={false} position="bottom-right" />
+      <FlowBlueprintBackground />
+      <FlowZoomControls />
+      <FlowPanHint />
     </ReactFlow>
   )
 }

--- a/frontend/src/components/agent/AgentFlowNodes.tsx
+++ b/frontend/src/components/agent/AgentFlowNodes.tsx
@@ -87,13 +87,15 @@ export const StepFlowNode = memo(({ data }: { data: StepNodeData }) => {
       }}
     >
       <Handle type="target" position={Position.Left} style={{ background: color, border: 'none', width: 8, height: 8 }} />
+      {/* Status accent strip, matching the Infra Map card language */}
+      <div style={{ position: 'absolute', left: 0, top: 9, bottom: 9, width: 3.5, borderRadius: 1.75, background: color }} />
       {step.status === 'pending_approval' && (
         <span style={{
           position: 'absolute', top: 8, right: 8, width: 8, height: 8, borderRadius: '50%',
           background: color, boxShadow: `0 0 0 4px color-mix(in srgb, ${color} 25%, transparent)`,
         }} className="agent-node-pulse" />
       )}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', borderBottom: '1px solid var(--border)', background: 'var(--bg-elevated)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px 10px 16px', borderBottom: '1px solid var(--border)', background: 'var(--bg-elevated)' }}>
         <div style={{
           width: 24, height: 24, borderRadius: 7, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
           background: 'var(--bg-card)', border: `1.5px solid ${color}`, color,

--- a/frontend/src/components/agent/FlowChrome.tsx
+++ b/frontend/src/components/agent/FlowChrome.tsx
@@ -1,0 +1,62 @@
+import { Background, BackgroundVariant, Panel, useReactFlow, useStore } from '@xyflow/react'
+import { ZoomIn, ZoomOut, Maximize } from 'lucide-react'
+
+// Shared canvas chrome for the Agent node-graphs (LauncherFlowCanvas,
+// AgentFlowCanvas), matching the Infra Map blueprint's visual language:
+// a fine line-grid backdrop, a zoom control card with a live percentage
+// readout, and a pan/zoom hint tag — so every node-graph in the app reads
+// as one consistent system rather than two different canvas styles.
+
+// Same 40px spacing as Infra Map's SVG grid pattern.
+export function FlowBlueprintBackground() {
+  return (
+    <Background
+      variant={BackgroundVariant.Lines}
+      gap={40}
+      lineWidth={1}
+      color="var(--border-light)"
+    />
+  )
+}
+
+export function FlowZoomControls() {
+  const { zoomIn, zoomOut, fitView } = useReactFlow()
+  const zoom = useStore(s => s.transform[2])
+
+  return (
+    <Panel position="bottom-right" style={{ margin: 12 }}>
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 4,
+        background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 8, padding: 4,
+      }}>
+        <button className="sidebar-toggle-btn" onClick={() => zoomIn({ duration: 150 })} title="Zoom in">
+          <ZoomIn size={14} />
+        </button>
+        <div style={{ textAlign: 'center', fontSize: 10, color: 'var(--text-muted)', fontFamily: 'var(--font-mono)', padding: '1px 0' }}>
+          {Math.round(zoom * 100)}%
+        </div>
+        <button className="sidebar-toggle-btn" onClick={() => zoomOut({ duration: 150 })} title="Zoom out">
+          <ZoomOut size={14} />
+        </button>
+        <button className="sidebar-toggle-btn" onClick={() => fitView({ padding: 0.25, duration: 300, maxZoom: 1 })} title="Fit to view">
+          <Maximize size={14} />
+        </button>
+      </div>
+    </Panel>
+  )
+}
+
+export function FlowPanHint() {
+  return (
+    <Panel position="bottom-left" style={{ margin: 12 }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 6,
+        fontSize: 10, color: 'var(--text-muted)', fontFamily: 'var(--font-mono)',
+        background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 8, padding: '4px 8px',
+        pointerEvents: 'none', opacity: 0.75,
+      }}>
+        drag to pan · scroll or pinch to zoom
+      </div>
+    </Panel>
+  )
+}

--- a/frontend/src/components/agent/LauncherFlowCanvas.tsx
+++ b/frontend/src/components/agent/LauncherFlowCanvas.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo } from 'react'
 import {
-  ReactFlow, ReactFlowProvider, Background, Controls, BackgroundVariant,
-  useReactFlow, type Node, type Edge, type NodeTypes,
+  ReactFlow, ReactFlowProvider, useReactFlow, type Node, type Edge, type NodeTypes,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import {
   ServerConfigNode, ProviderConfigNode, GoalConfigNode, TriggerConfigNode, type AgentProvider,
 } from './LauncherFlowNodes'
+import { FlowBlueprintBackground, FlowZoomControls, FlowPanHint } from './FlowChrome'
 import type { ServerData } from '../../pages/agentTypes'
 
 const nodeTypes: NodeTypes = {
@@ -78,14 +78,14 @@ function FlowInner(props: LauncherFlowCanvasProps) {
       edges={edges}
       nodeTypes={nodeTypes}
       proOptions={{ hideAttribution: true }}
-      minZoom={0.4}
-      maxZoom={1.5}
-      panOnScroll
+      minZoom={0.15}
+      maxZoom={3}
       nodesDraggable={false}
       fitView
     >
-      <Background variant={BackgroundVariant.Dots} gap={22} size={1.4} color="var(--border)" />
-      <Controls showInteractive={false} position="bottom-right" />
+      <FlowBlueprintBackground />
+      <FlowZoomControls />
+      <FlowPanHint />
     </ReactFlow>
   )
 }


### PR DESCRIPTION
## Summary
- Ports Infra Map's canvas visual language onto both Agent node-graphs (the launcher and the live/completed run view) via a new shared `FlowChrome.tsx`.
- Blueprint line-grid background, custom zoom control card with live percentage, matching pan/zoom hint tag.
- Unified interaction model: scroll/pinch to zoom, drag to pan (removed `panOnScroll`), matching Infra Map's convention.
- Hover-highlight-connected: hovering a node dims everything not directly connected to it.
- Step cards get the same colored left-edge accent strip as Infra Map's node cards.

## Test plan
- [x] tsc -b / eslint clean (verified zero new findings vs pre-edit files)
- [x] Verified in-browser: grid, zoom controls + percentage, pan hint render on both canvases, light/dark themes, real agent runs
- [x] Hover-highlight-connected algorithm verified correct in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)