### PR TITLE
build(desktop): stamp bundle version from package.json, bump to 1.6.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev infra backend frontend migrate build clean desktop-build desktop-package
+.PHONY: dev infra backend frontend migrate build clean desktop-build desktop-package desktop-stamp-version
 
 # Start core infrastructure in Docker (DB, Redis)
 # This uses official pre-built images, avoiding DNS/build issues
@@ -53,6 +53,7 @@ desktop-build:
 	rm -rf backend/cmd/desktop/frontenddist
 	mkdir -p backend/cmd/desktop/frontenddist
 	cp -R frontend/dist/. backend/cmd/desktop/frontenddist/
+	@$(MAKE) desktop-stamp-version
 	@APP_VERSION=$$(node -p "require('./frontend/package.json').version"); \
 	cd backend/cmd/desktop && \
 		if [ "$$(uname)" = "Darwin" ]; then \
@@ -62,6 +63,26 @@ desktop-build:
 		fi
 	@$(MAKE) desktop-package
 
+# Wails templates wails.json's info.productVersion into the bundle's
+# CFBundleShortVersionString / CFBundleVersion — it is not affected by the
+# -X main.appVersion ldflag, which only sets what the app reports about itself.
+# .github/workflows/desktop-release.yml stamps it from the release tag, so
+# released bundles are correct; a local `make desktop-build` had nothing doing
+# the same and produced a bundle whose Finder version disagreed with the app's.
+# package.json is already the source of truth for the ldflag and for the .deb
+# version in desktop-package, so take it from there too. Rewrites the file only
+# when the value actually differs, keeping a normal build a no-op on the tree.
+desktop-stamp-version:
+	@APP_VERSION=$$(node -p "require('./frontend/package.json').version"); \
+	node -e 'const fs=require("fs"),p="backend/cmd/desktop/wails.json",c=JSON.parse(fs.readFileSync(p,"utf8"));if(c.info.productVersion===process.argv[1]){process.exit(0)}c.info.productVersion=process.argv[1];fs.writeFileSync(p,JSON.stringify(c,null,2)+"\n");console.log("wails.json info.productVersion -> "+process.argv[1])' "$$APP_VERSION"
+
+# hdiutil, left to auto-size from -srcfolder, sizes the intermediate image off
+# the source's raw byte count, which undercounts a codesigned .app's extended
+# attributes — so it fails with "No space left on device" on a disk with tens of
+# GB free once the app is big enough. desktop-release.yml already sizes
+# explicitly off `du` plus headroom for this reason; this recipe had not caught
+# up, and now fails locally at ~90MB. Same fix here so the two agree.
+#
 # Wrap the raw `wails build` output (an unpacked .app on macOS, a bare ELF
 # binary on Linux) into the same installer format the GitHub release uses —
 # a double-clickable .dmg on macOS, a proper .deb on Linux — instead of
@@ -75,7 +96,8 @@ desktop-package:
 		mkdir dmg-staging && \
 		cp -R InfraEye.app dmg-staging/ && \
 		ln -s /Applications dmg-staging/Applications && \
-		hdiutil create -volname "InfraEye" -srcfolder dmg-staging -ov -format UDZO InfraEye.dmg && \
+		STAGING_MB=$$(du -sm dmg-staging | cut -f1) && \
+		hdiutil create -volname "InfraEye" -srcfolder dmg-staging -ov -format UDZO -size "$$((STAGING_MB + 200))m" InfraEye.dmg && \
 		rm -rf dmg-staging && \
 		echo "Installer ready: backend/cmd/desktop/build/bin/InfraEye.dmg (double-click to mount, then drag InfraEye to Applications)"; \
 	else \

--- a/backend/cmd/desktop/wails.json
+++ b/backend/cmd/desktop/wails.json
@@ -10,7 +10,7 @@
   "info": {
     "companyName": "InfraEye",
     "productName": "InfraEye",
-    "productVersion": "1.0.0",
+    "productVersion": "1.6.7",
     "copyright": "Copyright © 2026 InfraEye",
     "comments": "Agentless observability platform"
   }

--- a/backend/cmd/desktop/wails.json
+++ b/backend/cmd/desktop/wails.json
@@ -10,7 +10,7 @@
   "info": {
     "companyName": "InfraEye",
     "productName": "InfraEye",
-    "productVersion": "1.6.7",
+    "productVersion": "1.6.9",
     "copyright": "Copyright © 2026 InfraEye",
     "comments": "Agentless observability platform"
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.8",
+  "version": "1.6.9",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Prepares a `desktop-v1.6.9` release and fixes two ways `make desktop-build` had drifted from `desktop-release.yml`.

## Bundle version

Wails templates `wails.json`'s `info.productVersion` into `CFBundleShortVersionString` / `CFBundleVersion`. The `-X main.appVersion` ldflag only sets what the app reports about *itself*, so the two are independent.

`desktop-release.yml` stamps `productVersion` from the release tag, so tagged releases have always been correct. Nothing did the equivalent locally — it sat at `1.0.0` while the ldflag said `1.6.7`, so a locally built app showed one version in Finder and another in its own UI. It also meant a `workflow_dispatch` build (which skips the tag-gated stamp step) shipped a bundle claiming 1.0.0.

New `desktop-stamp-version` target takes it from `frontend/package.json`, already the source of truth for the ldflag and for the `.deb` version in `desktop-package`. It rewrites only when the value differs, so an ordinary build leaves the tree clean, and emits the same 2-space, non-ASCII-preserving JSON the workflow's Python does so local and CI produce an identical file.

## Dmg sizing

`hdiutil create -srcfolder` without `-size` estimates the intermediate image from the source's raw byte count, which undercounts a codesigned `.app`'s extended attributes. The workflow hit this, documented it, and fixed it by sizing off `du` plus 200MB headroom; this recipe never caught up. At ~90MB the app has crossed the threshold and packaging now fails locally with `No space left on device` on a disk with 10GB free. Same fix applied, so the two agree.

## Version

Bumped to **1.6.9**, covering the security fixes, read-only kubeconfig generator and frontend refactor from #120, plus the above. `desktop-v1.6.8` is already published (2026-08-18, 4 assets), so this goes out as a new version rather than re-cutting a shipped tag.

## Verified

Clean `make desktop-build` from an emptied `build/bin` on macOS arm64:

- `package.json`, `package-lock.json`, `wails.json`, `CFBundleShortVersionString` and the embedded ldflag all read the same version
- `InfraEye.dmg` builds, mounts, and contains the correctly versioned `.app`
- app launches, embedded backend answers on `127.0.0.1:8073`, quits cleanly
- `desktop-stamp-version` is idempotent — a second run is a no-op

Linux and Windows are untested locally; both are unaffected by the dmg change and pick up the version the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZfoeLcHvj2rPM7PEGKJbF