### PR TITLE
fix(desktop): self-update on pacman-based Linux (Arch/Omarchy)

### DIFF
--- a/backend/cmd/desktop/wails.json
+++ b/backend/cmd/desktop/wails.json
@@ -10,7 +10,7 @@
   "info": {
     "companyName": "InfraEye",
     "productName": "InfraEye",
-    "productVersion": "1.6.9",
+    "productVersion": "1.6.10",
     "copyright": "Copyright © 2026 InfraEye",
     "comments": "Agentless observability platform"
   }

--- a/backend/internal/updater/apply_linux.go
+++ b/backend/internal/updater/apply_linux.go
@@ -8,28 +8,45 @@ import (
 	"strings"
 )
 
-// Apply downloads the .deb at downloadURL and installs it via pkexec, which
-// shows the desktop's native polkit authentication dialog — there's no way
-// to install a system package without root, and this is the standard
-// GUI-friendly way to ask for it on Linux. Returns the installed binary's
-// path for the caller to relaunch.
+// Apply downloads the release asset at downloadURL and installs it via
+// pkexec, which shows the desktop's native polkit authentication dialog —
+// there's no way to install a system package without root, and this is the
+// standard GUI-friendly way to ask for it on Linux. The asset is either a
+// .deb (dpkg-based distros) or a .pkg.tar.zst (pacman-based distros, e.g.
+// Arch/Omarchy) — see assetNameFor, which already picked the one matching
+// this machine, so the extension alone tells us which installer to run.
+// Returns the installed binary's path for the caller to relaunch.
 func Apply(downloadURL string) (relaunchPath string, err error) {
 	if _, err := exec.LookPath("pkexec"); err != nil {
 		return "", fmt.Errorf("pkexec not found (needs polkit) — download and install manually instead: %s", downloadURL)
 	}
 
-	debPath, cleanup, err := download(downloadURL, "infraeye-update-*.deb")
+	var pattern, pkgManager string
+	var installArgs []string
+	if strings.HasSuffix(downloadURL, ".pkg.tar.zst") {
+		pattern, pkgManager = "infraeye-update-*.pkg.tar.zst", "pacman"
+	} else {
+		pattern, pkgManager = "infraeye-update-*.deb", "dpkg"
+	}
+
+	pkgPath, cleanup, err := download(downloadURL, pattern)
 	if err != nil {
 		return "", err
 	}
 	defer cleanup()
 
-	install := exec.Command("pkexec", "dpkg", "-i", debPath)
-	if out, err := install.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("dpkg install failed: %v: %s", err, strings.TrimSpace(string(out)))
+	if pkgManager == "pacman" {
+		installArgs = []string{"pacman", "-U", "--noconfirm", pkgPath}
+	} else {
+		installArgs = []string{"dpkg", "-i", pkgPath}
 	}
 
-	// The .deb always installs to this fixed path (see the CI packaging
+	install := exec.Command("pkexec", installArgs...)
+	if out, err := install.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("%s install failed: %v: %s", pkgManager, err, strings.TrimSpace(string(out)))
+	}
+
+	// Both package formats install to this fixed path (see the CI packaging
 	// step / Makefile's desktop-package target) — no need to guess.
 	return "/usr/bin/infraeye-desktop", nil
 }

--- a/backend/internal/updater/updater.go
+++ b/backend/internal/updater/updater.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -56,6 +57,9 @@ func assetNameFor() (string, error) {
 		}
 		return "InfraEye-macOS-arm64.dmg", nil
 	case "linux":
+		if _, err := exec.LookPath("pacman"); err == nil {
+			return "InfraEye-Linux.pkg.tar.zst", nil
+		}
 		return "InfraEye-Linux.deb", nil
 	case "windows":
 		return "InfraEye-Windows-amd64.exe", nil

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.9",
+  "version": "1.6.10",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- The desktop app's self-updater always downloaded `InfraEye-Linux.deb` and installed it via `pkexec dpkg -i`, which fails with exit 127 on any distro without dpkg — including Arch/Omarchy, where clicking "Update" in the dashboard errored with `Cannot run program dpkg: No such file or directory`.
- CI already publishes `InfraEye-Linux.pkg.tar.zst` alongside the `.deb` on every desktop release; the updater just never used it.
- `Check()` now picks the `.pkg.tar.zst` asset when `pacman` is on `PATH`, and `Apply()` installs it via `pkexec pacman -U --noconfirm` instead of `dpkg -i`.
- Bumps version to 1.6.10 (frontend/package.json, package-lock.json, wails.json productVersion via `make desktop-stamp-version`) so tagging `desktop-v1.6.10` ships this fix.

## Test plan
- [x] `cd backend && go build ./...` — builds clean
- [ ] Tag `desktop-v1.6.10` after merge, confirm CI publishes both `.deb` and `.pkg.tar.zst`
- [ ] On an Arch/Omarchy install, trigger "Update" in the dashboard and confirm it installs via pacman instead of failing on dpkg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vh5j8euV97qTcKXPEie6W