### PR TITLE
fix(k8s): rename read-only kubeconfig resources away from infraeye- prefix

### DIFF
--- a/backend/internal/handlers/k8s_kubeconfig.go
+++ b/backend/internal/handlers/k8s_kubeconfig.go
@@ -26,9 +26,9 @@ import (
 
 // Where the generated identities live. A dedicated namespace rather than
 // kube-system so every credential InfraEye hands out is visible, auditable, and
-// removable in one place (`kubectl delete ns infraeye-access` revokes them all).
+// removable in one place (`kubectl delete ns read-only` revokes them all).
 const (
-	readOnlyNamespace   = "infraeye-access"
+	readOnlyNamespace   = "read-only"
 	readOnlyClusterRole = "infraeye-readonly"
 	readOnlySAPrefix    = "infraeye-ro-"
 )

--- a/backend/internal/handlers/k8s_kubeconfig.go
+++ b/backend/internal/handlers/k8s_kubeconfig.go
@@ -29,8 +29,8 @@ import (
 // removable in one place (`kubectl delete ns read-only` revokes them all).
 const (
 	readOnlyNamespace   = "read-only"
-	readOnlyClusterRole = "infraeye-readonly"
-	readOnlySAPrefix    = "infraeye-ro-"
+	readOnlyClusterRole = "read-only"
+	readOnlySAPrefix    = "read-only-"
 )
 
 // maxTokenTTL is the ceiling the API server itself enforces on TokenRequest in


### PR DESCRIPTION
## Summary
- The read-only kubeconfig generator created every ServiceAccount/Secret/ClusterRole it issues under an `infraeye-access` namespace, an `infraeye-readonly` ClusterRole, and an `infraeye-ro-` ServiceAccount prefix.
- Renamed all three to drop the `infraeye-` branding, per request: namespace is now `read-only`, ClusterRole is `read-only`, ServiceAccount prefix is `read-only-`.
- Purely a constant rename — every reference in `k8s_kubeconfig.go` already derived from the three constants, so nothing else needed to change.

## Note
A cluster that already has the old `infraeye-access` namespace from before this fix (e.g. an existing Dev cluster) will need it deleted manually — `kubectl delete ns infraeye-access` — since a code change can't retroactively touch resources already created on a live cluster. New read-only access is issued into `read-only` going forward.

## Test plan
- [x] `cd backend && go build ./...` — builds clean
- [x] Confirmed no remaining references to `infraeye-ro`, `infraeye-readonly`, or `infraeye-access` anywhere in the codebase
- [ ] On a real cluster, generate a new read-only kubeconfig and confirm the `read-only` namespace/ClusterRole/ServiceAccount are created as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vh5j8euV97qTcKXPEie6W