### PR TITLE
fix(ai): update deprecated Gemini model, downgrade Mistral default tier

### DIFF
--- a/backend/internal/handlers/ai.go
+++ b/backend/internal/handlers/ai.go
@@ -645,7 +645,7 @@ func askAI(systemContext, question, imageBase64, imageMime, provider string, use
 }
 
 func askGemini(systemContext, question, imageBase64, imageMime, apiKey string) string {
-	apiURL := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=%s", apiKey)
+	apiURL := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/gemini-3.6-flash:generateContent?key=%s", apiKey)
 
 	parts := []geminiPart{
 		{Text: "SYSTEM CONTEXT: " + systemContext + "\n\nUSER QUESTION: " + question},
@@ -872,7 +872,9 @@ func askOpenRouter(systemContext, question, apiKey string) string {
 }
 
 func askMistral(systemContext, question, imageBase64, imageMime, apiKey string) string {
-	model := "mistral-large-latest"
+	// mistral-large-latest is paid-tier only and 403s on free/trial keys;
+	// mistral-small-latest is available on every tier.
+	model := "mistral-small-latest"
 	var content interface{} = "SYSTEM CONTEXT: " + systemContext + "\n\nUSER QUESTION: " + question
 
 	// If there's an image, switch to the multimodal-enabled model (Pixtral)


### PR DESCRIPTION
## Summary
Both surfaced via the verbatim-error-surfacing fix in #123 — real upstream errors that were previously masked by the generic "No response" fallback:

- **Gemini**: `gemini-2.0-flash` has been sunset by Google. Their own error response names the replacement (`models/gemini-3.6-flash`), so `askGemini` now uses that.
- **Mistral**: `mistral-large-latest` is paid-tier only and returns a 403 ("This model is not available in your subscription tier") on free/trial keys. Defaulted to `mistral-small-latest` instead, which every account tier can reach.

## Test plan
- [x] `cd backend && go build ./...` — builds clean
- [ ] With a Gemini key, confirm chat responses now work (previously errored on the sunset model)
- [ ] With a free/trial Mistral key, confirm chat responses now work instead of 403ing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vh5j8euV97qTcKXPEie6W