### PR TITLE
chore: bump version to 1.6.11

### DIFF
--- a/backend/cmd/desktop/wails.json
+++ b/backend/cmd/desktop/wails.json
@@ -10,7 +10,7 @@
   "info": {
     "companyName": "InfraEye",
     "productName": "InfraEye",
-    "productVersion": "1.6.10",
+    "productVersion": "1.6.11",
     "copyright": "Copyright © 2026 InfraEye",
     "comments": "Agentless observability platform"
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.10",
+      "version": "1.6.11",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.10",
+  "version": "1.6.11",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Covers the read-only kubeconfig namespace rename (#124) and the Gemini/Mistral model availability fixes (#125), both merged since desktop-v1.6.10. Bumps `frontend/package.json`, `package-lock.json`, and `wails.json` productVersion (via `make desktop-stamp-version`) so tagging `desktop-v1.6.11` ships both fixes.

## Test plan
- [x] `cd backend && go build ./...` — builds clean
- [x] `cd frontend && npx tsc -b` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vh5j8euV97qTcKXPEie6W