### PR TITLE
fix(audit): resolve CodeQL findings in the new scan-tool/export code

### DIFF
--- a/backend/internal/audit/tools.go
+++ b/backend/internal/audit/tools.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/infra-eye/backend/internal/db"
 )
@@ -43,6 +45,25 @@ func GetToolPathOverride(id string) string {
 // a typo here should fail loudly at save time, not silently at scan time.
 func SetToolPathOverride(id, path string) error {
 	if path != "" {
+		// Expand a leading "~" the way a shell would — the UI's own
+		// placeholder text suggests "~/codeql-home/...", so this has to keep
+		// working before the absolute-path check below.
+		if path == "~" || strings.HasPrefix(path, "~/") {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("resolve home directory: %w", err)
+			}
+			path = filepath.Join(home, strings.TrimPrefix(path, "~"))
+		}
+		// Require an absolute, cleaned path — this is an admin-only setting
+		// (the route is RequireRole("admin")) meant to point at one specific
+		// binary on this machine, not an arbitrary relative/traversal-style
+		// path resolved against whatever the server process's cwd happens to
+		// be at scan time.
+		path = filepath.Clean(path)
+		if !filepath.IsAbs(path) {
+			return fmt.Errorf("path must be absolute")
+		}
 		st, err := os.Stat(path)
 		if err != nil {
 			return fmt.Errorf("path does not exist: %w", err)

--- a/backend/internal/handlers/codeaudit.go
+++ b/backend/internal/handlers/codeaudit.go
@@ -412,6 +412,9 @@ func DastScanLogWS(c *gin.Context) {
 }
 
 func uintFromParam(s string) uint {
-	n, _ := strconv.ParseUint(s, 10, 64)
+	// Bound the parse to uint's actual bit width (32 on a 32-bit platform)
+	// rather than always 64, so the uint(n) conversion below can never
+	// silently truncate a value ParseUint accepted as valid.
+	n, _ := strconv.ParseUint(s, 10, strconv.IntSize)
 	return uint(n)
 }

--- a/frontend/src/utils/reportExport.ts
+++ b/frontend/src/utils/reportExport.ts
@@ -74,6 +74,14 @@ function csvCell(v: string): string {
   return v
 }
 
+// Escape backslashes before pipes, not after — otherwise a title already
+// containing a literal backslash (e.g. a Windows-style path) ends up with a
+// backslash directly in front of an unescaped pipe once ours is inserted,
+// which re-breaks the table row it was meant to protect.
+function escapeMdCell(v: string): string {
+  return v.replace(/\\/g, '\\\\').replace(/\|/g, '\\|')
+}
+
 /** Row-per-finding spreadsheet — the format a PM/tracking board actually wants to import. */
 export function downloadCSV(meta: ReportMeta, rows: ReportRow[]) {
   const header = ['Severity', 'Source', 'Category', 'Rule', 'Title', 'Location', 'Detail']
@@ -114,7 +122,7 @@ export function downloadMarkdown(meta: ReportMeta, rows: ReportRow[]) {
     lines.push('| Severity | Source | Rule | Title | Location |')
     lines.push('|---|---|---|---|---|')
     for (const r of sortedRows(rows)) {
-      lines.push(`| ${r.severity.toUpperCase()} | ${r.source} | ${r.rule} | ${r.title.replace(/\|/g, '\\|')} | ${r.location.replace(/\|/g, '\\|')} |`)
+      lines.push(`| ${r.severity.toUpperCase()} | ${r.source} | ${r.rule} | ${escapeMdCell(r.title)} | ${escapeMdCell(r.location)} |`)
     }
     lines.push('')
     lines.push('## Details')


### PR DESCRIPTION
## Summary
PR #127 (Code Security/DAST audit feature) was merged at 7f4218b, before a follow-up commit fixing 4 CodeQL findings on the new code had landed on the branch — so those findings are currently still open on `main`. This PR lands that fix on its own:

- `backend/internal/audit/tools.go`: require an absolute path for a tool's path override (with `~` expansion preserved, since the UI's own placeholder suggests it), closing a path-injection finding (`go/path-injection`, alert #24) on the admin-only path-override endpoint.
- `backend/internal/handlers/codeaudit.go`: bound `uintFromParam`'s `ParseUint` call to `strconv.IntSize` instead of always 64, so the `uint(n)` conversion can't silently truncate on a 32-bit platform (`go/incorrect-integer-conversion`, alert #25).
- `frontend/src/utils/reportExport.ts`: escape backslashes before pipes when building the Markdown findings table, so a title/location already containing a literal backslash can't re-break the escaping meant to protect it (`js/incomplete-sanitization`, alerts #22/#23).

## Test plan
- [x] `go build`/`go vet` on `cmd/server` + `internal/...`
- [x] `tsc -b` clean
- [x] Verified live against the running dev backend: absolute path accepted, relative path rejected with `"path must be absolute"`, `~`-relative path still resolves correctly (including through a `..` segment, confirming `filepath.Clean` neutralizes traversal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf