### PR TITLE
chore: bump version to 1.6.12

### DIFF
--- a/backend/cmd/desktop/wails.json
+++ b/backend/cmd/desktop/wails.json
@@ -10,7 +10,7 @@
   "info": {
     "companyName": "InfraEye",
     "productName": "InfraEye",
-    "productVersion": "1.6.11",
+    "productVersion": "1.6.12",
     "copyright": "Copyright © 2026 InfraEye",
     "comments": "Agentless observability platform"
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.11",
+      "version": "1.6.12",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.11",
+  "version": "1.6.12",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Covers the new Code Security (SAST/secrets/SCA/CodeQL) and DAST audit scanning (#127, #128) and the SSH exec-session PATH fix, both merged since desktop-v1.6.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf