### PR TITLE
fix(audit): fix report export not working in the desktop app

### DIFF
--- a/frontend/src/utils/reportExport.ts
+++ b/frontend/src/utils/reportExport.ts
@@ -1,6 +1,7 @@
 import jsPDF from 'jspdf'
 import autoTable from 'jspdf-autotable'
 import type { CodeFinding, DastFinding } from '../types/audit'
+import { saveFile } from './saveFile'
 
 /**
  * One finding, normalized to a shape both Code Security and DAST results can
@@ -58,15 +59,12 @@ function fileBase(meta: ReportMeta): string {
   return `${safe || 'report'}-${date}`
 }
 
+// Routes through the desktop app's native save dialog when running
+// Wails-bundled — its embedded webview doesn't implement the browser's
+// `<a download>` flow, so the anchor-click trick this used to do silently
+// no-ops there. See saveFile.ts.
 function triggerDownload(blob: Blob, filename: string) {
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
+  void saveFile(blob, filename)
 }
 
 function csvCell(v: string): string {
@@ -224,5 +222,8 @@ export function downloadPDF(meta: ReportMeta, rows: ReportRow[]) {
     doc.text(`InfraEye · generated ${new Date().toLocaleString()} · page ${i} of ${pageCount}`, margin, doc.internal.pageSize.getHeight() - 20)
   }
 
-  doc.save(`${fileBase(meta)}.pdf`)
+  // doc.save() drives the same anchor-click download jsPDF has always used,
+  // which is exactly what triggerDownload/saveFile exists to route around on
+  // desktop — so build the PDF as a blob and hand it to that instead.
+  triggerDownload(doc.output('blob'), `${fileBase(meta)}.pdf`)
 }


### PR DESCRIPTION
## Summary
Code Security/DAST report downloads (PDF/CSV/Markdown/JSON) silently did nothing in the desktop app while working fine on web (reported live by screenshot). Wails' embedded webview doesn't implement the browser's `<a download>` flow, so the anchor-click trick `reportExport.ts`'s `triggerDownload` used — and jsPDF's own `doc.save()`, which does the same thing internally — just no-ops there instead of showing a save dialog.

`InfraMap.tsx` already solves this exact problem for the blueprint export via `saveFile()` (`backend/cmd/desktop/app.go`'s `SaveFile` bridge — a native "Save As" dialog on desktop, the normal anchor-click download on web). This routes all four export formats through that same proven path instead of duplicating the workaround.

## Test plan
- [x] `tsc -b` clean
- [x] `go build`/`go vet` unaffected (no backend changes — `SaveFile` already exists and is already bound in `main.go`)
- [x] Built the desktop app locally with `wails build` to confirm it compiles and packages successfully with this change
- [x] Confirmed `SaveFile`'s Go implementation is generic (derives its file-type filter from whatever extension it's given), so it needs no changes to support `.pdf`/`.csv`/`.md`/`.json`
- [ ] Did not click through the actual native save dialog in this session (no Accessibility automation available in this environment) — the code path is identical to `InfraMap.tsx`'s already-shipping export, so risk is low, but worth a quick manual click-through before/after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf