### PR TITLE
fix(dast): avoid a flaky ZAP baseline-scan failure

### DIFF
--- a/backend/internal/audit/dast.go
+++ b/backend/internal/audit/dast.go
@@ -183,6 +183,18 @@ func runZAPViaDocker(ctx context.Context, dockerPath, targetURL, mode string, pr
 		"-J", "report.json", // JSON report; exit code is nonzero when alerts are found, which is expected
 		"-I", // don't fail the container run just because alerts were found
 	}
+	if script == "zap-baseline.py" {
+		// zap-baseline.py (unlike zap-full-scan.py) routes through ZAP's
+		// newer Automation Framework by default, which has a known flaky
+		// failure mode: "Failed to access summary file /home/zap/zap_out.json"
+		// — an internal completion-marker file the framework writes,
+		// unrelated to our -J report path, that intermittently fails for
+		// reasons upstream hasn't nailed down (see
+		// https://groups.google.com/g/zaproxy-users/c/rUzC7sS9NaA). --autooff
+		// reverts to the older direct-invocation path that doesn't have this
+		// marker file at all, at no cost to the scan itself.
+		args = append(args, "--autooff")
+	}
 	cmd := exec.CommandContext(ctx, dockerPath, args...)
 	// Neither stream is a parse target (the report comes from -J's file), so
 	// both stream live — this is also where a slow/first-time image pull


### PR DESCRIPTION
## Summary
Baseline DAST scans intermittently failed with:
```
zap scan produced no report: 2026-09-05 16:19:54,954 Failed to access summary file /home/zap/zap_out.json
```
reported live against a real target. Root cause: `zap-baseline.py` (unlike `zap-full-scan.py`) routes through ZAP's newer Automation Framework by default, which writes an internal completion-marker file (`zap_out.json`, unrelated to our own `-J report.json` output) that [intermittently fails to write for reasons upstream hasn't fully nailed down](https://groups.google.com/g/zaproxy-users/c/rUzC7sS9NaA). `zap-baseline.py --help` documents `--autooff` to bypass the Automation Framework entirely, reverting to the older direct-invocation path `zap-full-scan.py` already uses (which has no such marker file).

## Verification
- Reproduced against the real failing target directly with `docker run`: the exact same command that failed in the app succeeded seconds later on a bare retry — confirming this is upstream flakiness, not a bug in our command construction.
- Ran the same target with `--autooff` added: produced a valid `report.json` with real findings, both via a bare `docker run` and through the app's own `/api/audit/dast/targets/:id/scan` endpoint end-to-end.
- `go build`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf