### PR TITLE
fix(audit): persist and reload Code Security/DAST findings across navigation

### DIFF
--- a/backend/internal/handlers/codeaudit.go
+++ b/backend/internal/handlers/codeaudit.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -101,11 +102,35 @@ func SetAuditToolPath(c *gin.Context) {
 func ListCodeRepos(c *gin.Context) {
 	var repos []models.CodeRepo
 	db.DB.Order("name").Find(&repos)
+
+	scanByRepo := latestScansByTarget("code_repo", "code")
 	out := make([]gin.H, 0, len(repos))
 	for _, r := range repos {
-		out = append(out, codeRepoJSON(r))
+		item := codeRepoJSON(r)
+		if scan, ok := scanByRepo[r.ID]; ok {
+			var result audit.CodeScanResult
+			if err := json.Unmarshal([]byte(scan.ResultJSON), &result); err == nil {
+				item["last_result"] = result
+			}
+		}
+		out = append(out, item)
 	}
 	c.JSON(http.StatusOK, out)
+}
+
+// latestScansByTarget loads every persisted SecurityScan matching
+// (targetType, scanType) in one query, keyed by target ID — lets a list
+// endpoint attach each target's last scan result (so switching tabs and
+// coming back shows prior findings without forcing a rescan) without an
+// N+1 query per target.
+func latestScansByTarget(targetType, scanType string) map[uint]models.SecurityScan {
+	var scans []models.SecurityScan
+	db.DB.Where("target_type = ? AND scan_type = ?", targetType, scanType).Find(&scans)
+	out := make(map[uint]models.SecurityScan, len(scans))
+	for _, s := range scans {
+		out[s.TargetID] = s
+	}
+	return out
 }
 
 // codeRepoJSON never includes the PAT — same discipline as gitsync's
@@ -258,7 +283,23 @@ func firstNonEmptyStr(vals ...string) string {
 func ListDastTargets(c *gin.Context) {
 	var targets []models.DastTarget
 	db.DB.Order("name").Find(&targets)
-	c.JSON(http.StatusOK, targets)
+
+	scanByTarget := latestScansByTarget("dast_target", "dast")
+	out := make([]gin.H, 0, len(targets))
+	for _, t := range targets {
+		item := gin.H{
+			"id": t.ID, "name": t.Name, "target_url": t.TargetURL, "notes": t.Notes,
+			"created_at": t.CreatedAt, "updated_at": t.UpdatedAt,
+		}
+		if scan, ok := scanByTarget[t.ID]; ok {
+			var result audit.DastScanResult
+			if err := json.Unmarshal([]byte(scan.ResultJSON), &result); err == nil {
+				item["last_result"] = result
+			}
+		}
+		out = append(out, item)
+	}
+	c.JSON(http.StatusOK, out)
 }
 
 type dastTargetRequest struct {

--- a/frontend/src/pages/AuditCode.tsx
+++ b/frontend/src/pages/AuditCode.tsx
@@ -64,6 +64,11 @@ export function AuditCode() {
       ])
       setRepos(reposRes.data)
       setTools(toolsRes.data.code_scan_tools)
+      const persisted: Record<number, CodeScanResult> = {}
+      for (const r of reposRes.data) {
+        if (r.last_result) persisted[r.id] = r.last_result
+      }
+      setResults(persisted)
     } catch {
       setRepos([])
     } finally {

--- a/frontend/src/pages/AuditDast.tsx
+++ b/frontend/src/pages/AuditDast.tsx
@@ -65,6 +65,11 @@ export function AuditDast() {
       ])
       setTargets(targetsRes.data)
       setEnv(toolsRes.data.dast_environment)
+      const persisted: Record<number, DastScanResult> = {}
+      for (const t of targetsRes.data) {
+        if (t.last_result) persisted[t.id] = t.last_result
+      }
+      setResults(persisted)
     } catch {
       setTargets([])
     } finally {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -498,6 +498,7 @@ export function Dashboard() {
 
   const SCAN_TYPE_LABEL: Record<string, string> = {
     kernel: 'Kernel CVEs', hardening: 'OS Hardening', cluster: 'Cluster Posture', resource: 'Resource Exposure',
+    code: 'Code Security', dast: 'DAST',
   }
 
   // On short ranges show HH:MM; on 24h include the day so the axis reads clearly
@@ -774,7 +775,7 @@ export function Dashboard() {
                 icon={ShieldCheck}
                 iconColor={securityTotals && securityTotals.high > 0 ? 'var(--danger)' : 'var(--success)'}
                 title="Security Posture"
-                subtitle={`${securityScans.length} scan${securityScans.length === 1 ? '' : 's'} across kernel, hardening, cluster & resource checks`}
+                subtitle={`${securityScans.length} scan${securityScans.length === 1 ? '' : 's'} across kernel, hardening, cluster, resource, code & DAST checks`}
                 action={<button className="btn btn-secondary btn-sm" onClick={() => navigate('/audit/kernel')}>Review</button>}
               />
               {!securityTotals || securityTotals.findings === 0 ? (

--- a/frontend/src/types/audit.ts
+++ b/frontend/src/types/audit.ts
@@ -93,6 +93,7 @@ export interface CodeRepo {
   pat_set: boolean
   created_at: string
   updated_at: string
+  last_result?: CodeScanResult // most recent persisted scan, if this repo has ever been scanned
 }
 
 // ── DAST (dynamic application security testing) ──
@@ -128,6 +129,7 @@ export interface DastTarget {
   notes: string
   created_at: string
   updated_at: string
+  last_result?: DastScanResult // most recent persisted scan, if this target has ever been scanned
 }
 
 // ── Tool availability ──


### PR DESCRIPTION
## Summary
Reported live: "after doing the SAST and DAST scan the results are not preserved on the database, when I switch the tab, I don't get the scanned findings, which made me do rescan again to see the findings."

Root cause: scan results only ever lived in React component state. The backend already persists every scan's full result to `security_scans` (`saveSecurityScan`, the same mechanism kernel/hardening/cluster/resource scans use) — the Code Security and DAST pages just never read it back on load, so navigating away and back (or reloading) looked like the scan never happened.

## Changes
- `ListCodeRepos`/`ListDastTargets` now attach each repo/target's latest persisted result as `last_result` (one extra query per list call via `latestScansByTarget`, not N+1).
- `AuditCode.tsx`/`AuditDast.tsx` seed their `results` state from `last_result` on load instead of starting empty.
- Dashboard's Security Posture breakdown gets proper "Code Security"/"DAST" labels instead of falling back to the raw `code`/`dast` scan-type string — that data was already included in `/api/audit/summary`'s aggregate counts, just unlabeled.

## Verification
- `go build`/`go vet` and `tsc -b` both clean.
- Live: `GET /api/audit/code/repos` and `/api/audit/dast/targets` confirmed to return `last_result` with real finding counts for repos/targets scanned earlier in this session.
- Live in the browser: reloaded the Code Security page with zero new scans triggered — findings table rendered immediately from the persisted result ("SCANNED 3h ago" + full table), no rescan needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf