### PR TITLE
fix(audit): fix crash on Cluster/Kernel/Hardening/Resource scans with zero findings

### DIFF
--- a/backend/internal/audit/cluster.go
+++ b/backend/internal/audit/cluster.go
@@ -40,7 +40,10 @@ var knownEOLMinors = map[int]bool{
 // and reports workload, RBAC, and network-exposure risks.
 func ScanCluster(clientset *kubernetes.Clientset) (ClusterAuditResult, error) {
 	ctx := context.Background()
-	result := ClusterAuditResult{ScannedAt: time.Now()}
+	// Findings starts as an empty (non-nil) slice — a nil one marshals to
+	// JSON `null`, and the frontend calls .length/.map on it unconditionally
+	// once a result exists, which crashes the page on a clean scan.
+	result := ClusterAuditResult{ScannedAt: time.Now(), Findings: []ClusterFinding{}}
 
 	if v, err := clientset.Discovery().ServerVersion(); err == nil {
 		result.ServerVersion = v.String()

--- a/backend/internal/audit/hardening.go
+++ b/backend/internal/audit/hardening.go
@@ -62,7 +62,10 @@ func parseMarkerSections(output string, markers []string) map[string]string {
 // OS/SSH hardening checks.
 func ScanHardening(rawOutput string) HardeningAuditResult {
 	sec := parseMarkerSections(rawOutput, hardeningSectionMarkers)
-	result := HardeningAuditResult{ScannedAt: time.Now()}
+	// Checks starts as an empty (non-nil) slice — a nil one marshals to JSON
+	// `null`, and the frontend calls .length/.map on it unconditionally once
+	// a result exists, which crashes the page on a clean scan.
+	result := HardeningAuditResult{ScannedAt: time.Now(), Checks: []HardeningCheck{}}
 
 	sshd := sec["@@SSHD@@"]
 	sshdLower := strings.ToLower(sshd)

--- a/backend/internal/audit/kernel.go
+++ b/backend/internal/audit/kernel.go
@@ -335,10 +335,14 @@ func ScanKernel(rawOutput string) KernelAuditResult {
 	kernelVersion := strings.TrimSpace(sec.kernelVersion)
 	distro := parseDistroName(sec.distro)
 
+	// Findings starts as an empty (non-nil) slice — a nil one marshals to
+	// JSON `null`, and the frontend calls .length/.map on it unconditionally
+	// once a result exists, which crashes the page on a clean scan.
 	result := KernelAuditResult{
 		KernelVersion: kernelVersion,
 		Distro:        distro,
 		ScannedAt:     time.Now(),
+		Findings:      []KernelFinding{},
 	}
 
 	v, ok := parseVersion(kernelVersion)

--- a/backend/internal/audit/resource.go
+++ b/backend/internal/audit/resource.go
@@ -32,7 +32,10 @@ const resourceDialTimeout = 5 * time.Second
 // dials and, for TLS, completes a handshake — no credentials are guessed or
 // submitted.
 func ScanResource(res models.Resource) (ResourceAuditResult, error) {
-	result := ResourceAuditResult{ScannedAt: time.Now()}
+	// Findings starts as an empty (non-nil) slice — a nil one marshals to
+	// JSON `null`, and the frontend calls .length/.map on it unconditionally
+	// once a result exists, which crashes the page on a clean scan.
+	result := ResourceAuditResult{ScannedAt: time.Now(), Findings: []ResourceFinding{}}
 
 	directlyReachable := false
 	if conn, err := dialWithTimeout(res.Host, res.Port); err == nil {

--- a/frontend/src/pages/Audit.tsx
+++ b/frontend/src/pages/Audit.tsx
@@ -200,7 +200,7 @@ export function Audit() {
                           </tr>
                         </thead>
                         <tbody>
-                          {state.result.findings.map(f => (
+                          {(state.result.findings ?? []).map(f => (
                             <tr key={f.cve} style={{ borderBottom: '1px solid var(--border)' }}>
                               <td style={{ padding: '10px 16px' }}>
                                 <span style={{

--- a/frontend/src/pages/AuditCluster.tsx
+++ b/frontend/src/pages/AuditCluster.tsx
@@ -137,7 +137,7 @@ export function AuditCluster() {
                   </div>
 
                   {state?.result && isExpanded && (
-                    state.result.findings.length === 0 ? (
+                    (state.result.findings ?? []).length === 0 ? (
                       <div style={{ borderTop: '1px solid var(--border)', padding: '16px 20px', fontSize: 12, color: 'var(--text-muted)' }}>No findings.</div>
                     ) : (
                       <div style={{ borderTop: '1px solid var(--border)' }}>
@@ -152,7 +152,7 @@ export function AuditCluster() {
                             </tr>
                           </thead>
                           <tbody>
-                            {state.result.findings.map((f, i) => (
+                            {(state.result.findings ?? []).map((f, i) => (
                               <tr key={i} style={{ borderBottom: '1px solid var(--border)' }}>
                                 <td style={{ padding: '10px 16px', fontSize: 12, fontFamily: 'var(--font-mono)', textTransform: 'uppercase', fontWeight: 800, color: severityColor[f.severity] || 'var(--text-muted)' }}>{f.severity}</td>
                                 <td style={{ padding: '10px 16px', fontSize: 12, color: 'var(--text-secondary)', textTransform: 'uppercase' }}>{f.category}</td>

--- a/frontend/src/pages/AuditHardening.tsx
+++ b/frontend/src/pages/AuditHardening.tsx
@@ -142,7 +142,7 @@ export function AuditHardening() {
                           </tr>
                         </thead>
                         <tbody>
-                          {state.result.checks.map(chk => (
+                          {(state.result.checks ?? []).map(chk => (
                             <tr key={chk.id} style={{ borderBottom: '1px solid var(--border)' }}>
                               <td style={{ padding: '10px 16px' }}>
                                 {chk.passed

--- a/frontend/src/pages/AuditResources.tsx
+++ b/frontend/src/pages/AuditResources.tsx
@@ -139,7 +139,7 @@ export function AuditResources() {
                           </tr>
                         </thead>
                         <tbody>
-                          {state.result.findings.map((f, i) => (
+                          {(state.result.findings ?? []).map((f, i) => (
                             <tr key={i} style={{ borderBottom: '1px solid var(--border)' }}>
                               <td style={{ padding: '10px 16px' }}>
                                 {f.passed


### PR DESCRIPTION
## Summary
Reported live via screenshot: `http://localhost:5174/audit/cluster` crashed with `Cannot read properties of null (reading 'length')` when expanding a scan result.

Same root cause already fixed for Code Security/DAST scans in a prior PR, just never applied to the other four audit types: their Go result structs left the findings/checks slice at its nil zero value when a scan found nothing, which `encoding/json` renders as `null` rather than `[]`. The frontend's unconditional `.length`/`.map` calls on that field then crash the page.

## Changes
- `cluster.go`/`hardening.go`/`kernel.go`/`resource.go`: initialize `Findings`/`Checks` as an empty slice at construction.
- `Audit.tsx`/`AuditCluster.tsx`/`AuditHardening.tsx`/`AuditResources.tsx`: added `?? []` guards as belt-and-suspenders, matching what's already in `AuditCode.tsx`/`AuditDast.tsx`.

## Verification
- `go build`/`go vet` and `tsc -b` clean.
- Live: confirmed via a real cluster scan with zero findings that `findings` now serializes as `[]`, not `null`.
- Live in the browser: reproduced the exact crash on the pre-fix code (scan a clean cluster, expand) — after the fix, the same scan expands cleanly to "No findings."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf