### PR TITLE
style(alerts): tone down Alert Rules cards from per-metric rainbow to neutral

### DIFF
--- a/frontend/src/components/alerts/RuleCard.tsx
+++ b/frontend/src/components/alerts/RuleCard.tsx
@@ -13,7 +13,6 @@ interface Rule {
 interface RuleCardProps {
   rule: Rule;
   serverName: string;
-  condColor: string;
   canManage: boolean;
   onEdit: (r: Rule) => void;
   onDelete: (id: number) => void;
@@ -37,7 +36,7 @@ function conditionText(rule: Rule): string {
 }
 
 export const RuleCard = memo(({
-  rule, serverName, condColor, canManage, onEdit, onDelete, onToggle, confirmDelete, setConfirmDelete,
+  rule, serverName, canManage, onEdit, onDelete, onToggle, confirmDelete, setConfirmDelete,
 }: RuleCardProps) => {
   const isCritical = rule.severity === 'critical'
   return (
@@ -47,8 +46,11 @@ export const RuleCard = memo(({
       display: 'flex', flexDirection: 'column', gap: 14,
       opacity: rule.enabled ? 1 : 0.75,
     }}>
-      {/* Accent bar keyed to the metric being watched */}
-      <div style={{ position: 'absolute', top: 0, left: 0, bottom: 0, width: 3, background: rule.enabled ? condColor : 'var(--border)' }} />
+      {/* Accent bar: neutral by default, red only for a critical rule — a
+          color worth noticing, not a rainbow keyed to which metric it watches */}
+      {isCritical && (
+        <div style={{ position: 'absolute', top: 0, left: 0, bottom: 0, width: 3, background: 'var(--danger)' }} />
+      )}
 
       {/* Header */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 10 }}>
@@ -57,7 +59,7 @@ export const RuleCard = memo(({
             width: 36, height: 36, borderRadius: 'var(--radius-md)', background: 'var(--bg-elevated)',
             border: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
           }}>
-            <Zap size={16} color={condColor} />
+            <Zap size={16} color="var(--text-secondary)" />
           </div>
           <div style={{ minWidth: 0 }}>
             <div style={{ fontWeight: 800, color: 'var(--text-primary)', fontSize: 13.5, lineHeight: 1.3, wordBreak: 'break-word' }}>{rule.name}</div>
@@ -123,7 +125,7 @@ export const RuleCard = memo(({
             </span>
           ) : (
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 12.5, color: 'var(--text-secondary)', fontWeight: 600 }}>
-              <Bell size={12} style={{ color: condColor }} /> Notify only
+              <Bell size={12} style={{ color: 'var(--text-muted)' }} /> Notify only
             </span>
           )}
         </div>

--- a/frontend/src/pages/AlertRules.tsx
+++ b/frontend/src/pages/AlertRules.tsx
@@ -40,12 +40,6 @@ function escapeXmlAttr(s: string): string {
   return escapeXmlText(s).replace(/"/g, '&quot;')
 }
 
-const CONDITION_COLORS: Record<string, string> = {
-  cpu: '#f59e0b', mem: '#3b82f6', disk: '#ec4899',
-  load: '#10b981', log_keyword: '#ef4444',
-  pod_status: '#8b5cf6',
-}
-
 const METRICS: { value: string; label: string; hint: string }[] = [
   { value: 'cpu', label: 'CPU usage (%)', hint: 'Latest CPU utilization of the server' },
   { value: 'mem', label: 'Memory usage (%)', hint: 'Latest memory utilization of the server' },
@@ -408,7 +402,7 @@ export function AlertRules() {
           ) : (
             <div className="alert-rules-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))', gap: 16, paddingBottom: 40 }}>
               {rules.map(rule => (
-                <RuleCard key={rule.id} rule={rule} serverName={getServerName(rule.server_id)} condColor={CONDITION_COLORS[rule.condition_type] || 'var(--brand-primary)'} canManage={can('manage-alerts')} onEdit={handleEdit} onDelete={deleteRule} onToggle={toggleEnable} confirmDelete={confirmDelete} setConfirmDelete={setConfirmDelete} />
+                <RuleCard key={rule.id} rule={rule} serverName={getServerName(rule.server_id)} canManage={can('manage-alerts')} onEdit={handleEdit} onDelete={deleteRule} onToggle={toggleEnable} confirmDelete={confirmDelete} setConfirmDelete={setConfirmDelete} />
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary
Reported live via screenshot: the Alert Rules grid was "too colorful." Every card's left accent bar, watch icon, and "Notify only" bell were tinted by `CONDITION_COLORS`, a hardcoded per-metric-type map (CPU → orange, Memory → blue, Disk → pink, etc.) — so a page of 6 rules read as a color wheel with no relationship to severity or state.

## Changes
- Removed `CONDITION_COLORS` and the `condColor` prop entirely.
- The accent bar now only appears (in `--danger` red) for a critical-severity rule — color reserved for something actually worth noticing.
- Watch icon and "Notify only" bell are now a consistent neutral gray, matching the icon treatment already used on every other list page (`AuditCode.tsx`, `AuditDast.tsx`, etc.).
- Left the shared severity `Badge` component untouched — it's used consistently across the whole app for the same purpose.

## Verification
- `tsc -b` clean.
- Live in the browser: before/after screenshots confirm the grid now reads as consistently neutral cards, with the severity badge doing the one job that actually needs color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf