### PR TITLE
fix(ui): fix invisible icon buttons in dark mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -847,6 +847,23 @@ p {
 .btn-icon {
   padding: var(--space-2);
   aspect-ratio: 1;
+  /* Without an explicit color, this falls back to the browser's fixed
+     default button text color, which stays dark regardless of theme — on a
+     dark --bg-app that reads as an invisible icon (reported live: the
+     disconnect/delete cluster buttons on K8sClusterGrid). */
+  color: var(--text-secondary);
+}
+
+.btn-icon:hover:not(:disabled) {
+  color: var(--brand-primary);
+}
+
+.btn-icon.danger {
+  color: var(--danger);
+}
+
+.btn-icon.danger:hover:not(:disabled) {
+  color: var(--danger-dark);
 }
 
 /* ===== MODERN CARD SYSTEM ===== */


### PR DESCRIPTION
## Summary
Reported live via screenshot: the Disconnect/Delete cluster icon buttons on the Kubernetes page were invisible in dark mode (fine in light mode).

Root cause: `.btn-icon` never set a `color`, unlike `.btn-icon-sm` which already does (`color: var(--text-secondary)`). Without one, the icon falls back to the browser's fixed default button text color, which stays dark regardless of theme — invisible against a dark `--bg-app`. There was also no `.btn-icon.danger` rule at all, so that class name (used by several delete buttons) did nothing.

## Changes
Fixed at the shared `.btn-icon` class instead of per-component — this was the same latent bug in ~15 other places across the app (Alert Rules' edit/delete buttons, the Kubernetes resource explorer's per-resource action buttons, several modal close buttons). Verified live that Alert Rules had the identical invisible-icon issue and is fixed by the same change.

## Verification
- Live in the browser, light and dark mode: Kubernetes cluster disconnect/delete buttons and Alert Rules edit/delete buttons are now visibly gray/red respectively in both themes, with no visual regression in light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf