### PR TITLE
fix(ui): don't stack identical repeated toasts

### DIFF
--- a/frontend/src/store/toastStore.ts
+++ b/frontend/src/store/toastStore.ts
@@ -24,6 +24,17 @@ export const useToastStore = create<ToastStore>((set, get) => ({
   toasts: [],
 
   add: (toast) => {
+    // Skip if an identical toast (same type/title/message) is already
+    // showing — a repeatedly-polled failure (a flapping connection, a
+    // background health check) would otherwise wall the screen in stacked
+    // copies of the exact same message instead of just staying visible once.
+    // Genuinely different errors (a different title or message) still each
+    // get their own toast.
+    const isDuplicate = get().toasts.some(
+      (t) => t.type === toast.type && t.title === toast.title && t.message === toast.message
+    )
+    if (isDuplicate) return
+
     const id = Date.now().toString() + Math.random().toString(36).slice(2)
     const duration = toast.duration ?? (toast.type === 'error' ? 8000 : 4000)
     set((s) => ({ toasts: [...s.toasts, { ...toast, id }] }))


### PR DESCRIPTION
## Summary
Reported live via screenshots: the same error toast stacked up 5-8 times instead of staying visible once, walling the screen in duplicate red boxes (e.g. repeated "Connection failed" for a resource, or a burst of load-failure toasts during a backend outage).

## Root cause investigation
Two separate things were going on:
1. **The toast stacking itself**: `toastStore.add()` unconditionally appended every call with no deduplication.
2. **What triggered the repeats in this specific session**: a native Homebrew `postgresql@15` service had started on the host and was competing with the Docker-forwarded Postgres container for port 5432 — connections randomly landed on whichever server, explaining both the "relation users does not exist" (hit the native server, no schema) and "password authentication failed" (wrong creds for that server) errors seen in the screenshots. That's a host-machine conflict, not an app bug, and was resolved by stopping the native service (not a code change) — after confirming with the user first.

## Changes
Fixed the stacking itself, independent of root cause: `toastStore.add()` now skips adding when an identical toast (same type, title, and message) is already showing. A repeatedly-polled or repeatedly-retried failure stays as one toast instead of stacking; genuinely different errors (different title/message) still each get their own toast.

## Verification
- `tsc -b` clean.
- Live in the browser: clicking "Add resource" twice rapidly with an empty form (both trigger the identical "Validation error: Name is required" toast) now shows exactly one toast instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf