### PR TITLE
feat(resources): Redis key browser (Phase 2)

### DIFF
--- a/backend/internal/handlers/resource_redis.go
+++ b/backend/internal/handlers/resource_redis.go
@@ -1,0 +1,269 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/infra-eye/backend/internal/db"
+	"github.com/infra-eye/backend/internal/models"
+	"github.com/infra-eye/backend/internal/resources"
+	"github.com/redis/go-redis/v9"
+)
+
+// loadRedisResource is loadSQLResource's counterpart for Redis endpoints.
+func loadRedisResource(c *gin.Context) (models.Resource, bool) {
+	var resource models.Resource
+	if err := db.DB.First(&resource, c.Param("id")).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "resource not found"})
+		return resource, false
+	}
+	if resource.Protocol != "redis" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "only redis resources support key browsing"})
+		return resource, false
+	}
+	return resource, true
+}
+
+const defaultScanCount = 100
+
+// GetResourceRedisKeys lists keys matching pattern (default "*") via SCAN —
+// never KEYS, which blocks the whole server on a large keyspace. cursor is
+// opaque to the client: pass back whatever this returned until it comes back
+// "0", which means the scan is complete.
+func GetResourceRedisKeys(c *gin.Context) {
+	resource, ok := loadRedisResource(c)
+	if !ok {
+		return
+	}
+	pattern := c.DefaultQuery("pattern", "*")
+	cursor, _ := strconv.ParseUint(c.DefaultQuery("cursor", "0"), 10, 64)
+	count := int64(defaultScanCount)
+	if v, err := strconv.ParseInt(c.Query("count"), 10, 64); err == nil && v > 0 && v <= 1000 {
+		count = v
+	}
+
+	client := resources.OpenRedis(resource)
+	defer client.Close()
+
+	keys, nextCursor, err := client.Scan(c.Request.Context(), cursor, pattern, count).Result()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("scan failed: %v", err)})
+		return
+	}
+	if keys == nil {
+		keys = []string{}
+	}
+	c.JSON(http.StatusOK, gin.H{"keys": keys, "cursor": strconv.FormatUint(nextCursor, 10)})
+}
+
+// redisKeyResponse is the normalized shape every Redis type gets read into —
+// Value's actual shape depends on Type: string for "string", map[string]string
+// for "hash", []string for "list"/"set", []ZMember for "zset".
+type redisKeyResponse struct {
+	Key        string      `json:"key"`
+	Type       string      `json:"type"`
+	TTLSeconds int64       `json:"ttl_seconds"` // -1 = no expiry, -2 = key doesn't exist
+	Value      interface{} `json:"value"`
+}
+
+type zMember struct {
+	Member string  `json:"member"`
+	Score  float64 `json:"score"`
+}
+
+// GetResourceRedisKey reads one key's type, value, and TTL. key arrives as a
+// query parameter rather than a path segment specifically so it can contain
+// any byte a real Redis key might (colons, slashes, binary-ish text) without
+// route-parsing ambiguity.
+func GetResourceRedisKey(c *gin.Context) {
+	resource, ok := loadRedisResource(c)
+	if !ok {
+		return
+	}
+	key := c.Query("key")
+	if key == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "key is required"})
+		return
+	}
+
+	client := resources.OpenRedis(resource)
+	defer client.Close()
+	ctx := c.Request.Context()
+
+	keyType, err := client.Type(ctx, key).Result()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("type failed: %v", err)})
+		return
+	}
+	if keyType == "none" {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("key %q not found", key)})
+		return
+	}
+
+	ttl, err := client.TTL(ctx, key).Result()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("ttl failed: %v", err)})
+		return
+	}
+	ttlSeconds := int64(-1)
+	if ttl > 0 {
+		ttlSeconds = int64(ttl.Seconds())
+	}
+
+	var value interface{}
+	switch keyType {
+	case "string":
+		value, err = client.Get(ctx, key).Result()
+	case "hash":
+		value, err = client.HGetAll(ctx, key).Result()
+	case "list":
+		value, err = client.LRange(ctx, key, 0, -1).Result()
+	case "set":
+		value, err = client.SMembers(ctx, key).Result()
+	case "zset":
+		var zs []redis.Z
+		zs, err = client.ZRangeWithScores(ctx, key, 0, -1).Result()
+		members := make([]zMember, 0, len(zs))
+		for _, z := range zs {
+			member, _ := z.Member.(string)
+			members = append(members, zMember{Member: member, Score: z.Score})
+		}
+		value = members
+	default:
+		err = fmt.Errorf("unsupported redis type %q", keyType)
+	}
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("read value failed: %v", err)})
+		return
+	}
+
+	c.JSON(http.StatusOK, redisKeyResponse{Key: key, Type: keyType, TTLSeconds: ttlSeconds, Value: value})
+}
+
+type redisKeyWriteRequest struct {
+	Key         string            `json:"key" binding:"required"`
+	Type        string            `json:"type" binding:"required,oneof=string hash list set zset"`
+	StringValue string            `json:"string_value"` // type=string
+	Fields      map[string]string `json:"fields"`       // type=hash
+	Items       []string          `json:"items"`        // type=list|set
+	Members     []zMember         `json:"members"`      // type=zset
+	TTLSeconds  *int64            `json:"ttl_seconds"`  // nil = leave as-is (or no expiry for a new key); 0 = persist (remove TTL)
+}
+
+// PutResourceRedisKey replaces a key's value wholesale: for hash/list/set/
+// zset there's no partial "patch" concept here, so this deletes the key (if
+// it exists) and rewrites it from the request's fields/items/members — the
+// same "replace" semantics DataGrip-style tools use for a container value
+// you've edited as a whole in the UI, rather than diffing individual entries.
+func PutResourceRedisKey(c *gin.Context) {
+	resource, ok := loadRedisResource(c)
+	if !ok {
+		return
+	}
+	if !requireWriteAccess(c, resource.ID) {
+		return
+	}
+	var req redisKeyWriteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	client := resources.OpenRedis(resource)
+	defer client.Close()
+	ctx := c.Request.Context()
+
+	if req.Type != "string" {
+		// SET overwrites a string key outright; every other type needs the
+		// old value cleared first since HSET/RPUSH/SADD/ZADD only add to
+		// whatever's already there.
+		if err := client.Del(ctx, req.Key).Err(); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("clear existing value failed: %v", err)})
+			return
+		}
+	}
+
+	var err error
+	switch req.Type {
+	case "string":
+		err = client.Set(ctx, req.Key, req.StringValue, 0).Err()
+	case "hash":
+		if len(req.Fields) > 0 {
+			args := make([]interface{}, 0, len(req.Fields)*2)
+			for k, v := range req.Fields {
+				args = append(args, k, v)
+			}
+			err = client.HSet(ctx, req.Key, args...).Err()
+		}
+	case "list":
+		if len(req.Items) > 0 {
+			args := make([]interface{}, len(req.Items))
+			for i, v := range req.Items {
+				args[i] = v
+			}
+			err = client.RPush(ctx, req.Key, args...).Err()
+		}
+	case "set":
+		if len(req.Items) > 0 {
+			args := make([]interface{}, len(req.Items))
+			for i, v := range req.Items {
+				args[i] = v
+			}
+			err = client.SAdd(ctx, req.Key, args...).Err()
+		}
+	case "zset":
+		if len(req.Members) > 0 {
+			zs := make([]redis.Z, len(req.Members))
+			for i, m := range req.Members {
+				zs[i] = redis.Z{Score: m.Score, Member: m.Member}
+			}
+			err = client.ZAdd(ctx, req.Key, zs...).Err()
+		}
+	}
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("write failed: %v", err)})
+		return
+	}
+
+	if req.TTLSeconds != nil {
+		if *req.TTLSeconds <= 0 {
+			client.Persist(ctx, req.Key)
+		} else {
+			client.Expire(ctx, req.Key, time.Duration(*req.TTLSeconds)*time.Second)
+		}
+	}
+
+	logResourceAudit(c, resource.ID, currentUserID(c), "edit_redis_key", gin.H{"key": req.Key, "type": req.Type})
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// DeleteResourceRedisKey deletes one key.
+func DeleteResourceRedisKey(c *gin.Context) {
+	resource, ok := loadRedisResource(c)
+	if !ok {
+		return
+	}
+	if !requireWriteAccess(c, resource.ID) {
+		return
+	}
+	key := c.Query("key")
+	if key == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "key is required"})
+		return
+	}
+
+	client := resources.OpenRedis(resource)
+	defer client.Close()
+
+	deleted, err := client.Del(c.Request.Context(), key).Result()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("delete failed: %v", err)})
+		return
+	}
+
+	logResourceAudit(c, resource.ID, currentUserID(c), "delete_redis_key", gin.H{"key": key})
+	c.JSON(http.StatusOK, gin.H{"deleted": deleted})
+}

--- a/backend/internal/httpapi/routes.go
+++ b/backend/internal/httpapi/routes.go
@@ -100,6 +100,10 @@ func RegisterRoutes(r *gin.Engine) {
 		api.POST("/resources/:id/schema/:schema/:table/rows", middleware.RequireRole("admin", "devops"), handlers.PostResourceTableRow)
 		api.PUT("/resources/:id/schema/:schema/:table/rows", middleware.RequireRole("admin", "devops"), handlers.PutResourceTableRow)
 		api.DELETE("/resources/:id/schema/:schema/:table/rows", middleware.RequireRole("admin", "devops"), handlers.DeleteResourceTableRow)
+		api.GET("/resources/:id/redis/keys", middleware.RequireRole("admin", "devops"), handlers.GetResourceRedisKeys)
+		api.GET("/resources/:id/redis/key", middleware.RequireRole("admin", "devops"), handlers.GetResourceRedisKey)
+		api.PUT("/resources/:id/redis/key", middleware.RequireRole("admin", "devops"), handlers.PutResourceRedisKey)
+		api.DELETE("/resources/:id/redis/key", middleware.RequireRole("admin", "devops"), handlers.DeleteResourceRedisKey)
 		api.PATCH("/resources/:id/folder", middleware.RequireRole("admin", "devops"), handlers.MoveResourceFolder)
 		api.GET("/resources/:id/audit/security", middleware.RequireRole("admin", "devops", "trainee"), handlers.ScanResourceSecurity)
 

--- a/backend/internal/resources/probe.go
+++ b/backend/internal/resources/probe.go
@@ -14,7 +14,6 @@ import (
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
-	"github.com/redis/go-redis/v9"
 	"github.com/segmentio/kafka-go"
 
 	"github.com/infra-eye/backend/internal/models"
@@ -182,15 +181,7 @@ func mysqlStatusInt(ctx context.Context, conn *sql.DB, name string) int64 {
 // ── Redis ───────────────────────────────────────────────────────────────────
 
 func probeRedis(ctx context.Context, r models.Resource) ProbeResult {
-	opt := &redis.Options{
-		Addr:        net.JoinHostPort(r.Host, strconv.Itoa(r.Port)),
-		Password:    firstNonEmpty(r.Password, r.Secret),
-		DialTimeout: 6 * time.Second,
-		Dialer: func(_ context.Context, _, _ string) (net.Conn, error) {
-			return DialResource(r.Host, r.Port, r.UseGateway)
-		},
-	}
-	client := redis.NewClient(opt)
+	client := OpenRedis(r)
 	defer client.Close()
 
 	if err := client.Ping(ctx).Err(); err != nil {

--- a/backend/internal/resources/redis.go
+++ b/backend/internal/resources/redis.go
@@ -1,0 +1,29 @@
+package resources
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/infra-eye/backend/internal/models"
+)
+
+// OpenRedis returns a gateway-aware Redis client for r — the same
+// DialResource choke point every other resource operation uses, via
+// dialResourceCtx so the caller's own context timeout is respected rather
+// than blocking for DialResource's longer internal one. Shared by probeRedis
+// (health-check) and the key-browser handlers so there's exactly one place
+// that builds a Redis connection for a resource.
+func OpenRedis(r models.Resource) *redis.Client {
+	return redis.NewClient(&redis.Options{
+		Addr:        net.JoinHostPort(r.Host, strconv.Itoa(r.Port)),
+		Password:    firstNonEmpty(r.Password, r.Secret),
+		DialTimeout: 6 * time.Second,
+		Dialer: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialResourceCtx(ctx, r.Host, r.Port, r.UseGateway)
+		},
+	})
+}

--- a/frontend/src/components/database/RedisBrowser.tsx
+++ b/frontend/src/components/database/RedisBrowser.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useState } from 'react'
+import {
+  Search, Loader2, Trash2, Plus, X, Save, Key as KeyIcon, Clock, RefreshCw,
+} from 'lucide-react'
+import { api } from '../../api/client'
+import { useToastStore } from '../../store/toastStore'
+import { errMessage } from '../../utils/errors'
+import type { RedisKeysResponse, RedisKeyDetail, RedisType, ZMember } from '../../types/redis'
+
+interface RedisBrowserProps {
+  resourceId: number
+  canEdit: boolean
+}
+
+const typeColor: Record<RedisType, string> = {
+  string: 'var(--brand-primary)', hash: 'var(--success)', list: 'var(--warning)',
+  set: 'var(--info)', zset: 'var(--danger)',
+}
+
+function fmtTtl(sec: number): string {
+  if (sec < 0) return 'no expiry'
+  if (sec < 60) return `${sec}s`
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ${sec % 60}s`
+  return `${Math.floor(sec / 3600)}h ${Math.floor((sec % 3600) / 60)}m`
+}
+
+/**
+ * Key list (pattern-filtered, cursor-paginated via SCAN) + a detail panel
+ * that edits a key's value as a whole, shaped per Redis type — the same
+ * "replace" semantics the backend's PUT .../redis/key implements.
+ */
+export function RedisBrowser({ resourceId, canEdit }: RedisBrowserProps) {
+  const toast = useToastStore()
+  const [pattern, setPattern] = useState('*')
+  const [keys, setKeys] = useState<string[]>([])
+  const [cursor, setCursor] = useState('0')
+  const [loadingKeys, setLoadingKeys] = useState(true)
+
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [detail, setDetail] = useState<RedisKeyDetail | null>(null)
+  const [loadingDetail, setLoadingDetail] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  // Draft editors per type
+  const [draftString, setDraftString] = useState('')
+  const [draftFields, setDraftFields] = useState<{ k: string; v: string }[]>([])
+  const [draftItems, setDraftItems] = useState<string[]>([])
+  const [draftMembers, setDraftMembers] = useState<ZMember[]>([])
+  const [draftTtl, setDraftTtl] = useState<string>('')
+
+  async function loadKeys(reset: boolean) {
+    setLoadingKeys(true)
+    try {
+      const res = await api.get<RedisKeysResponse>(`/api/resources/${resourceId}/redis/keys`, {
+        params: { pattern, cursor: reset ? '0' : cursor, count: 200 },
+      })
+      setKeys(prev => reset ? res.data.keys : [...prev, ...res.data.keys])
+      setCursor(res.data.cursor)
+    } catch (err: unknown) {
+      toast.error('Scan failed', errMessage(err))
+    } finally {
+      setLoadingKeys(false)
+    }
+  }
+
+  useEffect(() => { loadKeys(true) }, [resourceId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function selectKey(key: string) {
+    setSelectedKey(key)
+    setLoadingDetail(true)
+    setDetail(null)
+    try {
+      const res = await api.get<RedisKeyDetail>(`/api/resources/${resourceId}/redis/key`, { params: { key } })
+      setDetail(res.data)
+      setDraftTtl(res.data.ttl_seconds >= 0 ? String(res.data.ttl_seconds) : '')
+      if (res.data.type === 'string') setDraftString(res.data.value as string)
+      else if (res.data.type === 'hash') setDraftFields(Object.entries(res.data.value as Record<string, string>).map(([k, v]) => ({ k, v })))
+      else if (res.data.type === 'list' || res.data.type === 'set') setDraftItems([...(res.data.value as string[])])
+      else if (res.data.type === 'zset') setDraftMembers([...(res.data.value as ZMember[])])
+    } catch (err: unknown) {
+      toast.error('Load failed', errMessage(err, 'Could not load key'))
+    } finally {
+      setLoadingDetail(false)
+    }
+  }
+
+  async function save() {
+    if (!detail) return
+    setSaving(true)
+    try {
+      const ttlSeconds = draftTtl.trim() === '' ? null : Number(draftTtl)
+      const body: Record<string, unknown> = { key: detail.key, type: detail.type, ttl_seconds: ttlSeconds }
+      if (detail.type === 'string') body.string_value = draftString
+      else if (detail.type === 'hash') body.fields = Object.fromEntries(draftFields.filter(f => f.k.trim() !== '').map(f => [f.k, f.v]))
+      else if (detail.type === 'list' || detail.type === 'set') body.items = draftItems.filter(i => i !== '')
+      else if (detail.type === 'zset') body.members = draftMembers
+
+      await api.put(`/api/resources/${resourceId}/redis/key`, body)
+      toast.success('Key saved', detail.key)
+      selectKey(detail.key)
+    } catch (err: unknown) {
+      toast.error('Save failed', errMessage(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function deleteKey(key: string) {
+    try {
+      await api.delete(`/api/resources/${resourceId}/redis/key`, { params: { key } })
+      toast.success('Key deleted', key)
+      setKeys(prev => prev.filter(k => k !== key))
+      if (selectedKey === key) { setSelectedKey(null); setDetail(null) }
+    } catch (err: unknown) {
+      toast.error('Delete failed', errMessage(err))
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', height: '100%' }}>
+      <div style={{ width: 260, flexShrink: 0, borderRight: '1px solid var(--border)', display: 'flex', flexDirection: 'column' }}>
+        <div style={{ padding: 10, borderBottom: '1px solid var(--border)', display: 'flex', gap: 6 }}>
+          <div style={{ position: 'relative', flex: 1 }}>
+            <Search size={12} style={{ position: 'absolute', left: 8, top: 9, color: 'var(--text-muted)' }} />
+            <input className="input" value={pattern} onChange={e => setPattern(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') loadKeys(true) }}
+              placeholder="pattern (e.g. user:*)" style={{ fontSize: 12, padding: '6px 8px 6px 26px', height: 28, fontFamily: 'var(--font-mono)' }} />
+          </div>
+          <button className="btn-icon" onClick={() => loadKeys(true)} title="Scan" style={{ width: 28, height: 28 }}><RefreshCw size={13} /></button>
+        </div>
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {loadingKeys && keys.length === 0 ? (
+            <div style={{ padding: 20, display: 'flex', alignItems: 'center', gap: 8, color: 'var(--text-muted)', fontSize: 12.5 }}>
+              <Loader2 size={14} className="spin" /> Scanning…
+            </div>
+          ) : keys.length === 0 ? (
+            <div style={{ padding: 16, fontSize: 12.5, color: 'var(--text-muted)' }}>No keys match.</div>
+          ) : (
+            <>
+              {keys.map(key => (
+                <button key={key} onClick={() => selectKey(key)}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 6, width: '100%', padding: '6px 12px',
+                    background: selectedKey === key ? 'var(--brand-glow)' : 'none', border: 'none', cursor: 'pointer', textAlign: 'left',
+                    fontSize: 12.5, fontFamily: 'var(--font-mono)', color: selectedKey === key ? 'var(--brand-primary)' : 'var(--text-secondary)',
+                  }}>
+                  <KeyIcon size={11} style={{ flexShrink: 0 }} />
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{key}</span>
+                </button>
+              ))}
+              {cursor !== '0' && (
+                <button onClick={() => loadKeys(false)} disabled={loadingKeys} className="btn btn-secondary btn-sm" style={{ margin: 10, width: 'calc(100% - 20px)' }}>
+                  {loadingKeys ? <Loader2 size={12} className="spin" /> : 'Load more'}
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflow: 'auto', padding: selectedKey ? 20 : 0 }}>
+        {!selectedKey ? (
+          <div style={{ padding: 40, textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
+            <KeyIcon size={28} style={{ opacity: 0.3, marginBottom: 10 }} />
+            <div>Select a key to view its value.</div>
+          </div>
+        ) : loadingDetail || !detail ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'var(--text-muted)' }}>
+            <Loader2 size={16} className="spin" /> Loading {selectedKey}…
+          </div>
+        ) : (
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16, flexWrap: 'wrap', gap: 10 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 14, fontWeight: 700 }}>{detail.key}</span>
+                <span style={{ padding: '2px 8px', fontSize: 11, fontWeight: 800, textTransform: 'uppercase', color: typeColor[detail.type], border: `1px solid ${typeColor[detail.type]}40` }}>{detail.type}</span>
+              </div>
+              {canEdit && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 12, color: 'var(--text-muted)' }}>
+                    <Clock size={12} />
+                    <input className="input" value={draftTtl} onChange={e => setDraftTtl(e.target.value)} placeholder="no expiry"
+                      style={{ width: 90, fontSize: 12, padding: '4px 8px', height: 26, fontFamily: 'var(--font-mono)' }} />
+                    sec
+                  </span>
+                  <button className="btn btn-primary btn-sm" onClick={save} disabled={saving} style={{ gap: 6 }}>
+                    {saving ? <Loader2 size={13} className="spin" /> : <Save size={13} />} Save
+                  </button>
+                  <button className="btn-icon danger" onClick={() => deleteKey(detail.key)} title="Delete key" style={{ width: 30, height: 30 }}><Trash2 size={14} /></button>
+                </div>
+              )}
+              {!canEdit && (
+                <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>TTL: {fmtTtl(detail.ttl_seconds)}</span>
+              )}
+            </div>
+
+            {detail.type === 'string' && (
+              <textarea className="input" value={draftString} onChange={e => setDraftString(e.target.value)} disabled={!canEdit}
+                style={{ width: '100%', minHeight: 200, fontFamily: 'var(--font-mono)', fontSize: 13, padding: 12 }} />
+            )}
+
+            {detail.type === 'hash' && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {draftFields.map((f, i) => (
+                  <div key={i} style={{ display: 'flex', gap: 6 }}>
+                    <input className="input" value={f.k} disabled={!canEdit} placeholder="field"
+                      onChange={e => setDraftFields(prev => prev.map((x, j) => j === i ? { ...x, k: e.target.value } : x))}
+                      style={{ flex: 1, fontFamily: 'var(--font-mono)', fontSize: 12.5, padding: '6px 10px', height: 32 }} />
+                    <input className="input" value={f.v} disabled={!canEdit} placeholder="value"
+                      onChange={e => setDraftFields(prev => prev.map((x, j) => j === i ? { ...x, v: e.target.value } : x))}
+                      style={{ flex: 2, fontFamily: 'var(--font-mono)', fontSize: 12.5, padding: '6px 10px', height: 32 }} />
+                    {canEdit && <button className="btn-icon danger" onClick={() => setDraftFields(prev => prev.filter((_, j) => j !== i))} style={{ width: 32, height: 32 }}><X size={13} /></button>}
+                  </div>
+                ))}
+                {canEdit && (
+                  <button className="btn btn-secondary btn-sm" onClick={() => setDraftFields(prev => [...prev, { k: '', v: '' }])} style={{ alignSelf: 'flex-start', gap: 6 }}>
+                    <Plus size={13} /> Add field
+                  </button>
+                )}
+              </div>
+            )}
+
+            {(detail.type === 'list' || detail.type === 'set') && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {draftItems.map((v, i) => (
+                  <div key={i} style={{ display: 'flex', gap: 6 }}>
+                    <input className="input" value={v} disabled={!canEdit}
+                      onChange={e => setDraftItems(prev => prev.map((x, j) => j === i ? e.target.value : x))}
+                      style={{ flex: 1, fontFamily: 'var(--font-mono)', fontSize: 12.5, padding: '6px 10px', height: 32 }} />
+                    {canEdit && <button className="btn-icon danger" onClick={() => setDraftItems(prev => prev.filter((_, j) => j !== i))} style={{ width: 32, height: 32 }}><X size={13} /></button>}
+                  </div>
+                ))}
+                {canEdit && (
+                  <button className="btn btn-secondary btn-sm" onClick={() => setDraftItems(prev => [...prev, ''])} style={{ alignSelf: 'flex-start', gap: 6 }}>
+                    <Plus size={13} /> Add item
+                  </button>
+                )}
+              </div>
+            )}
+
+            {detail.type === 'zset' && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {draftMembers.map((m, i) => (
+                  <div key={i} style={{ display: 'flex', gap: 6 }}>
+                    <input className="input" value={m.member} disabled={!canEdit} placeholder="member"
+                      onChange={e => setDraftMembers(prev => prev.map((x, j) => j === i ? { ...x, member: e.target.value } : x))}
+                      style={{ flex: 2, fontFamily: 'var(--font-mono)', fontSize: 12.5, padding: '6px 10px', height: 32 }} />
+                    <input className="input" type="number" value={m.score} disabled={!canEdit} placeholder="score"
+                      onChange={e => setDraftMembers(prev => prev.map((x, j) => j === i ? { ...x, score: Number(e.target.value) } : x))}
+                      style={{ width: 100, fontFamily: 'var(--font-mono)', fontSize: 12.5, padding: '6px 10px', height: 32 }} />
+                    {canEdit && <button className="btn-icon danger" onClick={() => setDraftMembers(prev => prev.filter((_, j) => j !== i))} style={{ width: 32, height: 32 }}><X size={13} /></button>}
+                  </div>
+                ))}
+                {canEdit && (
+                  <button className="btn btn-secondary btn-sm" onClick={() => setDraftMembers(prev => [...prev, { member: '', score: 0 }])} style={{ alignSelf: 'flex-start', gap: 6 }}>
+                    <Plus size={13} /> Add member
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ResourceDetail.tsx
+++ b/frontend/src/pages/ResourceDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import {
   ArrowLeft, Database, Shield, ShieldCheck, Trash2, Plus, Clock3,
   Table, Loader2, Globe, Activity, User, Lock, History, Code, RefreshCw,
-  Gauge, Zap, Layers, Cpu, CircleDot, AlertTriangle, HardDrive
+  Gauge, Zap, Layers, Cpu, CircleDot, AlertTriangle, HardDrive, KeyRound
 } from 'lucide-react'
 import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip,
@@ -17,6 +17,7 @@ import type { IconComponent } from '../types/k8s'
 import { SchemaTree } from '../components/database/SchemaTree'
 import { DataGrid } from '../components/database/DataGrid'
 import { SqlConsole } from '../components/database/SqlConsole'
+import { RedisBrowser } from '../components/database/RedisBrowser'
 
 interface ResourceDetailData {
   id: number; name: string; description?: string; tags?: string
@@ -28,7 +29,7 @@ interface UserData { id: number; username: string; email?: string; role: string 
 interface AccessEntry { id: number; resource_id: number; user_id: number; access_level: string; user?: UserData; created_at?: string }
 interface AuditEntry { id: number; resource_id: number; user_id: number; action: string; details: string; performed_by: string; created_at: string }
 interface MetricRow { id: number; timestamp: string; status: string; latency_ms: number; error?: string; metrics: string }
-type ResourceTab = 'observability' | 'overview' | 'database' | 'access' | 'audit'
+type ResourceTab = 'observability' | 'overview' | 'database' | 'redis' | 'access' | 'audit'
 
 interface LiveProbe { status: string; latency_ms: number; error?: string; metrics: Record<string, unknown> }
 
@@ -160,6 +161,7 @@ export function ResourceDetail() {
   const [dbView, setDbView] = useState<'browse' | 'console'>('browse')
 
   const isSqlable = ['postgres', 'postgresql', 'mysql', 'mariadb'].includes(resource?.protocol ?? '')
+  const isRedis = resource?.protocol === 'redis'
 
   useEffect(() => { if (id) loadPageData() }, [id])
   useEffect(() => { if (activeTab === 'audit') loadAudit() }, [auditLimit, auditSince, auditUntil, activeTab])
@@ -309,6 +311,7 @@ export function ResourceDetail() {
     { id: 'observability', label: 'Observability', icon: Gauge },
     { id: 'overview', label: 'Overview', icon: Database },
     ...(isSqlable ? [{ id: 'database', label: 'Database', icon: Code }] : []),
+    ...(isRedis ? [{ id: 'redis', label: 'Keys', icon: KeyRound }] : []),
     { id: 'access', label: 'Access', icon: Lock },
     { id: 'audit', label: 'Audit Log', icon: History },
   ]
@@ -552,6 +555,13 @@ export function ResourceDetail() {
               )}
             </div>
           </div>
+        </div>
+      )}
+
+      {/* ── Redis keys ── */}
+      {activeTab === 'redis' && resource && (
+        <div className="card" style={{ padding: 0, height: 'calc(100vh - 280px)', minHeight: 500, overflow: 'hidden' }}>
+          <RedisBrowser resourceId={resource.id} canEdit={can('manage-resources')} />
         </div>
       )}
 

--- a/frontend/src/types/redis.ts
+++ b/frontend/src/types/redis.ts
@@ -1,0 +1,20 @@
+// ── Redis key browser ──
+
+export type RedisType = 'string' | 'hash' | 'list' | 'set' | 'zset'
+
+export interface RedisKeysResponse {
+  keys: string[]
+  cursor: string // "0" means the scan is complete
+}
+
+export interface ZMember {
+  member: string
+  score: number
+}
+
+export interface RedisKeyDetail {
+  key: string
+  type: RedisType
+  ttl_seconds: number // -1 = no expiry
+  value: string | Record<string, string> | string[] | ZMember[]
+}


### PR DESCRIPTION
## Summary

Phase 2 of the DataGrip-style Resources UI (Phase 1: Postgres/MySQL Database tab, already merged in #139). Adds a Redis "Keys" tab that lets you browse, edit, and delete keys of every Redis type through the resource gateway.

**Backend** (`backend/internal/resources/redis.go`, `backend/internal/handlers/resource_redis.go`):
- `OpenRedis(r)` — gateway-aware `*redis.Client`, reused by `probeRedis` (replacing its inline `redis.Options` construction)
- `GET /resources/:id/redis/keys` — `SCAN`-based key listing (never `KEYS *`) with `pattern`/`cursor`/`count` params
- `GET /resources/:id/redis/key?key=...` — type-detect (`TYPE`) + type-appropriate read (`GET`/`HGETALL`/`LRANGE`/`SMEMBERS`/`ZRANGE WITHSCORES`) + `TTL`
- `PUT /resources/:id/redis/key` — replace-semantics write (`DEL` then rewrite for hash/list/set/zset, plain `SET` for strings) + TTL via `PERSIST`/`EXPIRE`; gated by `requireWriteAccess`, audit-logged as `edit_redis_key`
- `DELETE /resources/:id/redis/key?key=...` — gated, audit-logged as `delete_redis_key`

**Frontend** (`frontend/src/components/database/RedisBrowser.tsx`, `frontend/src/types/redis.ts`, `ResourceDetail.tsx`):
- New "Keys" tab shown only for `protocol === 'redis'`
- Key list with pattern filter and cursor-based "Load more" pagination
- Type-specific detail editors: string (textarea), hash (field/value pairs), list/set (item list), zset (member/score pairs), plus a TTL field and Save/Delete actions gated on write access

## Test plan

Live-verified end-to-end in the browser against a seeded `demo-redis` resource (backed by the real `infra-eye-redis` Docker container), covering all 5 Redis types:
- [x] Key list loads and shows all seeded keys with pattern filter
- [x] String key: view value + live-counting TTL
- [x] Hash key: edit a field, save, confirm toast + persisted change
- [x] List key: remove an item, add a new item, save, confirm order and contents persist
- [x] Set key: view members
- [x] Zset key: view member/score pairs
- [x] Delete a key, confirm it disappears from the list and from Redis
- [x] `go build`/`go vet` clean (scoped to `./cmd/server/... ./internal/...`)
- [x] `npx tsc -b` clean
- [x] Test resource and seeded test keys cleaned up after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf