### PR TITLE
feat(resources): Kafka topic browser (Phase 3)

### DIFF
--- a/backend/internal/handlers/resource_kafka.go
+++ b/backend/internal/handlers/resource_kafka.go
@@ -1,0 +1,337 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/segmentio/kafka-go"
+
+	"github.com/infra-eye/backend/internal/db"
+	"github.com/infra-eye/backend/internal/models"
+	"github.com/infra-eye/backend/internal/resources"
+)
+
+// loadKafkaResource is loadRedisResource's counterpart for Kafka endpoints.
+// Kafka browsing is read-only, so unlike SQL/Redis there is no write gate.
+func loadKafkaResource(c *gin.Context) (models.Resource, bool) {
+	var resource models.Resource
+	if err := db.DB.First(&resource, c.Param("id")).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "resource not found"})
+		return resource, false
+	}
+	if resource.Protocol != "kafka" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "only kafka resources support topic browsing"})
+		return resource, false
+	}
+	return resource, true
+}
+
+type kafkaTopicInfo struct {
+	Name       string `json:"name"`
+	Partitions int    `json:"partitions"`
+}
+
+// GetResourceKafkaTopics lists topics (excluding internal __-prefixed ones,
+// same convention as the observability probe) with their partition counts.
+func GetResourceKafkaTopics(c *gin.Context) {
+	resource, ok := loadKafkaResource(c)
+	if !ok {
+		return
+	}
+	ctx := c.Request.Context()
+	dialer := resources.KafkaDialer(resource)
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(resource.Host, strconv.Itoa(resource.Port)))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("dial failed: %v", err)})
+		return
+	}
+	defer conn.Close()
+
+	partitions, err := conn.ReadPartitions()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("read partitions failed: %v", err)})
+		return
+	}
+
+	counts := map[string]int{}
+	for _, p := range partitions {
+		if strings.HasPrefix(p.Topic, "__") {
+			continue
+		}
+		counts[p.Topic]++
+	}
+	topics := make([]kafkaTopicInfo, 0, len(counts))
+	for name, n := range counts {
+		topics = append(topics, kafkaTopicInfo{Name: name, Partitions: n})
+	}
+	sort.Slice(topics, func(i, j int) bool { return topics[i].Name < topics[j].Name })
+
+	c.JSON(http.StatusOK, gin.H{"topics": topics})
+}
+
+type kafkaPartitionOffset struct {
+	Partition int   `json:"partition"`
+	Low       int64 `json:"low"`  // oldest available offset
+	High      int64 `json:"high"` // next offset to be written (high watermark)
+}
+
+// GetResourceKafkaTopicOffsets reports each partition's low/high watermark
+// for one topic, dialing each partition's leader directly (the bootstrap
+// connection alone can't answer offset queries).
+func GetResourceKafkaTopicOffsets(c *gin.Context) {
+	resource, ok := loadKafkaResource(c)
+	if !ok {
+		return
+	}
+	topic := c.Param("topic")
+	ctx := c.Request.Context()
+	dialer := resources.KafkaDialer(resource)
+	addr := net.JoinHostPort(resource.Host, strconv.Itoa(resource.Port))
+
+	bootstrap, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("dial failed: %v", err)})
+		return
+	}
+	partitions, err := bootstrap.ReadPartitions(topic)
+	bootstrap.Close()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("read partitions failed: %v", err)})
+		return
+	}
+	if len(partitions) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("topic %q not found", topic)})
+		return
+	}
+
+	result := make([]kafkaPartitionOffset, 0, len(partitions))
+	for _, p := range partitions {
+		leader, err := dialer.DialLeader(ctx, "tcp", addr, topic, p.ID)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("dial leader for partition %d failed: %v", p.ID, err)})
+			return
+		}
+		low, lowErr := leader.ReadFirstOffset()
+		high, highErr := leader.ReadLastOffset()
+		leader.Close()
+		if lowErr != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("read low offset for partition %d failed: %v", p.ID, lowErr)})
+			return
+		}
+		if highErr != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("read high offset for partition %d failed: %v", p.ID, highErr)})
+			return
+		}
+		result = append(result, kafkaPartitionOffset{Partition: p.ID, Low: low, High: high})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Partition < result[j].Partition })
+
+	c.JSON(http.StatusOK, gin.H{"topic": topic, "partitions": result})
+}
+
+type kafkaMessage struct {
+	Partition int       `json:"partition"`
+	Offset    int64     `json:"offset"`
+	Key       string    `json:"key"`
+	Value     string    `json:"value"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+const (
+	defaultMessageLimit = 20
+	maxMessageLimit     = 200
+)
+
+// GetResourceKafkaMessages tails the most recent messages on one partition:
+// it reads the low/high watermark first, seeks a reader to high-limit (never
+// below low), and reads forward to the high watermark — a bounded read, not
+// a live/streaming subscription.
+func GetResourceKafkaMessages(c *gin.Context) {
+	resource, ok := loadKafkaResource(c)
+	if !ok {
+		return
+	}
+	topic := c.Param("topic")
+	partition, err := strconv.Atoi(c.DefaultQuery("partition", "0"))
+	if err != nil || partition < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "partition must be a non-negative integer"})
+		return
+	}
+	limit := defaultMessageLimit
+	if v, err := strconv.Atoi(c.Query("limit")); err == nil && v > 0 && v <= maxMessageLimit {
+		limit = v
+	}
+
+	ctx := c.Request.Context()
+	dialer := resources.KafkaDialer(resource)
+	addr := net.JoinHostPort(resource.Host, strconv.Itoa(resource.Port))
+
+	leader, err := dialer.DialLeader(ctx, "tcp", addr, topic, partition)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("dial leader failed: %v", err)})
+		return
+	}
+	low, lowErr := leader.ReadFirstOffset()
+	high, highErr := leader.ReadLastOffset()
+	leader.Close()
+	if lowErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("read low offset failed: %v", lowErr)})
+		return
+	}
+	if highErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("read high offset failed: %v", highErr)})
+		return
+	}
+	if high <= low {
+		c.JSON(http.StatusOK, gin.H{"messages": []kafkaMessage{}})
+		return
+	}
+
+	start := high - int64(limit)
+	if start < low {
+		start = low
+	}
+
+	reader := kafka.NewReader(kafka.ReaderConfig{
+		Brokers:   []string{addr},
+		Topic:     topic,
+		Partition: partition,
+		Dialer:    dialer,
+		MinBytes:  1,
+		MaxBytes:  10e6,
+	})
+	defer reader.Close()
+	if err := reader.SetOffset(start); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("seek failed: %v", err)})
+		return
+	}
+
+	readCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	want := high - start
+	messages := make([]kafkaMessage, 0, want)
+	for int64(len(messages)) < want {
+		m, err := reader.ReadMessage(readCtx)
+		if err != nil {
+			break // deadline hit or reader closed — return whatever was read so far
+		}
+		messages = append(messages, kafkaMessage{
+			Partition: m.Partition,
+			Offset:    m.Offset,
+			Key:       string(m.Key),
+			Value:     string(m.Value),
+			Timestamp: m.Time,
+		})
+	}
+
+	logResourceAudit(c, resource.ID, currentUserID(c), "browse_kafka_messages", gin.H{"topic": topic, "partition": partition, "count": len(messages)})
+	c.JSON(http.StatusOK, gin.H{"messages": messages})
+}
+
+type kafkaGroupPartition struct {
+	Topic           string `json:"topic"`
+	Partition       int    `json:"partition"`
+	CommittedOffset int64  `json:"committed_offset"`
+	HighWatermark   int64  `json:"high_watermark"`
+	Lag             int64  `json:"lag"`
+}
+
+type kafkaGroupInfo struct {
+	GroupID      string                `json:"group_id"`
+	ProtocolType string                `json:"protocol_type"`
+	TotalLag     int64                 `json:"total_lag"`
+	Partitions   []kafkaGroupPartition `json:"partitions"`
+}
+
+// GetResourceKafkaGroups lists consumer groups and, for each, its committed
+// offset / high-watermark / lag per topic-partition it has offsets for.
+func GetResourceKafkaGroups(c *gin.Context) {
+	resource, ok := loadKafkaResource(c)
+	if !ok {
+		return
+	}
+	ctx := c.Request.Context()
+	client := resources.KafkaClient(resource)
+	addr := kafka.TCP(net.JoinHostPort(resource.Host, strconv.Itoa(resource.Port)))
+
+	listResp, err := client.ListGroups(ctx, &kafka.ListGroupsRequest{Addr: addr})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("list groups failed: %v", err)})
+		return
+	}
+	if listResp.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": listResp.Error.Error()})
+		return
+	}
+
+	dialer := resources.KafkaDialer(resource)
+	hostPort := net.JoinHostPort(resource.Host, strconv.Itoa(resource.Port))
+	highCache := map[string]map[int]int64{}
+	highWatermark := func(topic string, partition int) (int64, error) {
+		if byPart, ok := highCache[topic]; ok {
+			if v, ok := byPart[partition]; ok {
+				return v, nil
+			}
+		} else {
+			highCache[topic] = map[int]int64{}
+		}
+		leader, err := dialer.DialLeader(ctx, "tcp", hostPort, topic, partition)
+		if err != nil {
+			return 0, err
+		}
+		defer leader.Close()
+		h, err := leader.ReadLastOffset()
+		if err != nil {
+			return 0, err
+		}
+		highCache[topic][partition] = h
+		return h, nil
+	}
+
+	groups := make([]kafkaGroupInfo, 0, len(listResp.Groups))
+	for _, g := range listResp.Groups {
+		info := kafkaGroupInfo{GroupID: g.GroupID, ProtocolType: g.ProtocolType, Partitions: []kafkaGroupPartition{}}
+
+		offResp, err := client.OffsetFetch(ctx, &kafka.OffsetFetchRequest{Addr: addr, GroupID: g.GroupID})
+		if err == nil && offResp.Error == nil {
+			for topic, parts := range offResp.Topics {
+				for _, p := range parts {
+					high, hErr := highWatermark(topic, p.Partition)
+					var lag int64
+					if hErr == nil {
+						lag = high - p.CommittedOffset
+						if lag < 0 {
+							lag = 0
+						}
+					}
+					info.Partitions = append(info.Partitions, kafkaGroupPartition{
+						Topic:           topic,
+						Partition:       p.Partition,
+						CommittedOffset: p.CommittedOffset,
+						HighWatermark:   high,
+						Lag:             lag,
+					})
+					info.TotalLag += lag
+				}
+			}
+			sort.Slice(info.Partitions, func(i, j int) bool {
+				if info.Partitions[i].Topic != info.Partitions[j].Topic {
+					return info.Partitions[i].Topic < info.Partitions[j].Topic
+				}
+				return info.Partitions[i].Partition < info.Partitions[j].Partition
+			})
+		}
+		groups = append(groups, info)
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].GroupID < groups[j].GroupID })
+
+	c.JSON(http.StatusOK, gin.H{"groups": groups})
+}

--- a/backend/internal/httpapi/routes.go
+++ b/backend/internal/httpapi/routes.go
@@ -104,6 +104,10 @@ func RegisterRoutes(r *gin.Engine) {
 		api.GET("/resources/:id/redis/key", middleware.RequireRole("admin", "devops"), handlers.GetResourceRedisKey)
 		api.PUT("/resources/:id/redis/key", middleware.RequireRole("admin", "devops"), handlers.PutResourceRedisKey)
 		api.DELETE("/resources/:id/redis/key", middleware.RequireRole("admin", "devops"), handlers.DeleteResourceRedisKey)
+		api.GET("/resources/:id/kafka/topics", middleware.RequireRole("admin", "devops"), handlers.GetResourceKafkaTopics)
+		api.GET("/resources/:id/kafka/topics/:topic/offsets", middleware.RequireRole("admin", "devops"), handlers.GetResourceKafkaTopicOffsets)
+		api.GET("/resources/:id/kafka/topics/:topic/messages", middleware.RequireRole("admin", "devops"), handlers.GetResourceKafkaMessages)
+		api.GET("/resources/:id/kafka/groups", middleware.RequireRole("admin", "devops"), handlers.GetResourceKafkaGroups)
 		api.PATCH("/resources/:id/folder", middleware.RequireRole("admin", "devops"), handlers.MoveResourceFolder)
 		api.GET("/resources/:id/audit/security", middleware.RequireRole("admin", "devops", "trainee"), handlers.ScanResourceSecurity)
 

--- a/backend/internal/resources/kafka.go
+++ b/backend/internal/resources/kafka.go
@@ -1,0 +1,39 @@
+package resources
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+
+	"github.com/infra-eye/backend/internal/models"
+)
+
+// KafkaDialer returns a gateway-aware dialer for a Kafka resource, the same
+// dialer shape probeKafka already uses for connectivity checks.
+func KafkaDialer(r models.Resource) *kafka.Dialer {
+	return &kafka.Dialer{
+		Timeout: 8 * time.Second,
+		DialFunc: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialResourceCtx(ctx, r.Host, r.Port, r.UseGateway)
+		},
+	}
+}
+
+// KafkaClient returns a gateway-aware kafka.Client for broker-level requests
+// (ListGroups, OffsetFetch) that the connection-oriented kafka.Conn API
+// doesn't expose.
+func KafkaClient(r models.Resource) *kafka.Client {
+	return &kafka.Client{
+		Addr:    kafka.TCP(net.JoinHostPort(r.Host, strconv.Itoa(r.Port))),
+		Timeout: 8 * time.Second,
+		Transport: &kafka.Transport{
+			DialTimeout: 8 * time.Second,
+			Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return dialResourceCtx(ctx, r.Host, r.Port, r.UseGateway)
+			},
+		},
+	}
+}

--- a/backend/internal/resources/probe.go
+++ b/backend/internal/resources/probe.go
@@ -14,7 +14,6 @@ import (
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
-	"github.com/segmentio/kafka-go"
 
 	"github.com/infra-eye/backend/internal/models"
 )
@@ -244,12 +243,7 @@ func parseRedisInfo(info string) map[string]string {
 // ── Kafka ───────────────────────────────────────────────────────────────────
 
 func probeKafka(ctx context.Context, r models.Resource) ProbeResult {
-	dialer := &kafka.Dialer{
-		Timeout: 6 * time.Second,
-		DialFunc: func(_ context.Context, _, _ string) (net.Conn, error) {
-			return DialResource(r.Host, r.Port, r.UseGateway)
-		},
-	}
+	dialer := KafkaDialer(r)
 	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(r.Host, strconv.Itoa(r.Port)))
 	if err != nil {
 		return offline(err)

--- a/frontend/src/components/database/KafkaBrowser.tsx
+++ b/frontend/src/components/database/KafkaBrowser.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useState } from 'react'
+import { Layers, Users, Loader2, RefreshCw, ChevronDown, ChevronRight, MessageSquare } from 'lucide-react'
+import { api } from '../../api/client'
+import { useToastStore } from '../../store/toastStore'
+import { errMessage } from '../../utils/errors'
+import type {
+  KafkaTopicInfo, KafkaTopicsResponse, KafkaOffsetsResponse, KafkaPartitionOffset,
+  KafkaMessage, KafkaMessagesResponse, KafkaGroupInfo, KafkaGroupsResponse,
+} from '../../types/kafka'
+
+interface KafkaBrowserProps {
+  resourceId: number
+}
+
+type Selection = { kind: 'topic'; name: string } | { kind: 'group'; id: string } | null
+
+const cellStyle: React.CSSProperties = { padding: '6px 10px', fontSize: 12.5, fontFamily: 'var(--font-mono)', borderBottom: '1px solid var(--border)' }
+const headStyle: React.CSSProperties = { padding: '6px 10px', fontSize: 11, fontWeight: 700, textTransform: 'uppercase', color: 'var(--text-muted)', textAlign: 'left', borderBottom: '1px solid var(--border)' }
+
+function fmtTime(ts: string): string {
+  const d = new Date(ts)
+  return isNaN(d.getTime()) ? ts : d.toLocaleString()
+}
+
+/**
+ * Read-only Kafka topic browser: topic list with partition low/high
+ * watermarks, a bounded recent-message tail per partition, and consumer
+ * group lag. No write path — Kafka topics aren't edited through a grid the
+ * way SQL rows or Redis keys are.
+ */
+export function KafkaBrowser({ resourceId }: KafkaBrowserProps) {
+  const toast = useToastStore()
+  const [topics, setTopics] = useState<KafkaTopicInfo[]>([])
+  const [groups, setGroups] = useState<KafkaGroupInfo[]>([])
+  const [loadingList, setLoadingList] = useState(true)
+  const [topicsOpen, setTopicsOpen] = useState(true)
+  const [groupsOpen, setGroupsOpen] = useState(true)
+
+  const [selection, setSelection] = useState<Selection>(null)
+
+  const [offsets, setOffsets] = useState<KafkaPartitionOffset[]>([])
+  const [loadingOffsets, setLoadingOffsets] = useState(false)
+  const [partition, setPartition] = useState(0)
+  const [messages, setMessages] = useState<KafkaMessage[]>([])
+  const [loadingMessages, setLoadingMessages] = useState(false)
+  const [messageLimit, setMessageLimit] = useState(20)
+
+  async function loadLists() {
+    setLoadingList(true)
+    try {
+      const [topicsRes, groupsRes] = await Promise.all([
+        api.get<KafkaTopicsResponse>(`/api/resources/${resourceId}/kafka/topics`),
+        api.get<KafkaGroupsResponse>(`/api/resources/${resourceId}/kafka/groups`),
+      ])
+      setTopics(topicsRes.data.topics ?? [])
+      setGroups(groupsRes.data.groups ?? [])
+    } catch (err: unknown) {
+      toast.error('Load failed', errMessage(err, 'Could not load Kafka topics/groups'))
+    } finally {
+      setLoadingList(false)
+    }
+  }
+
+  useEffect(() => { loadLists() }, [resourceId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function selectTopic(name: string) {
+    setSelection({ kind: 'topic', name })
+    setPartition(0)
+    setMessages([])
+    setLoadingOffsets(true)
+    try {
+      const res = await api.get<KafkaOffsetsResponse>(`/api/resources/${resourceId}/kafka/topics/${encodeURIComponent(name)}/offsets`)
+      setOffsets(res.data.partitions ?? [])
+    } catch (err: unknown) {
+      toast.error('Load failed', errMessage(err, 'Could not load partition offsets'))
+      setOffsets([])
+    } finally {
+      setLoadingOffsets(false)
+    }
+  }
+
+  async function loadMessages(topic: string, p: number, limit: number) {
+    setLoadingMessages(true)
+    try {
+      const res = await api.get<KafkaMessagesResponse>(`/api/resources/${resourceId}/kafka/topics/${encodeURIComponent(topic)}/messages`, {
+        params: { partition: p, limit },
+      })
+      setMessages(res.data.messages ?? [])
+    } catch (err: unknown) {
+      toast.error('Load failed', errMessage(err, 'Could not load messages'))
+    } finally {
+      setLoadingMessages(false)
+    }
+  }
+
+  useEffect(() => {
+    if (selection?.kind === 'topic') loadMessages(selection.name, partition, messageLimit)
+  }, [selection, partition]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const selectedGroup = selection?.kind === 'group' ? groups.find(g => g.group_id === selection.id) : undefined
+
+  return (
+    <div style={{ display: 'flex', height: '100%' }}>
+      <div style={{ width: 260, flexShrink: 0, borderRight: '1px solid var(--border)', display: 'flex', flexDirection: 'column' }}>
+        <div style={{ padding: 10, borderBottom: '1px solid var(--border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-secondary)' }}>Kafka</span>
+          <button className="btn-icon" onClick={loadLists} title="Refresh" style={{ width: 26, height: 26 }}><RefreshCw size={12} /></button>
+        </div>
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {loadingList ? (
+            <div style={{ padding: 20, display: 'flex', alignItems: 'center', gap: 8, color: 'var(--text-muted)', fontSize: 12.5 }}>
+              <Loader2 size={14} className="spin" /> Loading…
+            </div>
+          ) : (
+            <>
+              <button onClick={() => setTopicsOpen(o => !o)} style={{
+                display: 'flex', alignItems: 'center', gap: 6, width: '100%', padding: '8px 10px', background: 'none',
+                border: 'none', cursor: 'pointer', fontSize: 12, fontWeight: 700, color: 'var(--text-secondary)',
+              }}>
+                {topicsOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+                <Layers size={13} /> Topics ({topics.length})
+              </button>
+              {topicsOpen && topics.map(t => (
+                <button key={t.name} onClick={() => selectTopic(t.name)}
+                  style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', padding: '6px 12px 6px 30px',
+                    background: selection?.kind === 'topic' && selection.name === t.name ? 'var(--brand-glow)' : 'none', border: 'none', cursor: 'pointer', textAlign: 'left',
+                    fontSize: 12.5, fontFamily: 'var(--font-mono)', color: selection?.kind === 'topic' && selection.name === t.name ? 'var(--brand-primary)' : 'var(--text-secondary)',
+                  }}>
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t.name}</span>
+                  <span style={{ fontSize: 10.5, color: 'var(--text-muted)', flexShrink: 0, marginLeft: 6 }}>{t.partitions}p</span>
+                </button>
+              ))}
+              {topics.length === 0 && topicsOpen && (
+                <div style={{ padding: '4px 12px 8px 30px', fontSize: 12, color: 'var(--text-muted)' }}>No topics.</div>
+              )}
+
+              <button onClick={() => setGroupsOpen(o => !o)} style={{
+                display: 'flex', alignItems: 'center', gap: 6, width: '100%', padding: '8px 10px', background: 'none',
+                border: 'none', cursor: 'pointer', fontSize: 12, fontWeight: 700, color: 'var(--text-secondary)', marginTop: 6,
+              }}>
+                {groupsOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+                <Users size={13} /> Consumer groups ({groups.length})
+              </button>
+              {groupsOpen && groups.map(g => (
+                <button key={g.group_id} onClick={() => setSelection({ kind: 'group', id: g.group_id })}
+                  style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', padding: '6px 12px 6px 30px',
+                    background: selection?.kind === 'group' && selection.id === g.group_id ? 'var(--brand-glow)' : 'none', border: 'none', cursor: 'pointer', textAlign: 'left',
+                    fontSize: 12.5, fontFamily: 'var(--font-mono)', color: selection?.kind === 'group' && selection.id === g.group_id ? 'var(--brand-primary)' : 'var(--text-secondary)',
+                  }}>
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{g.group_id}</span>
+                  {g.total_lag > 0 && (
+                    <span style={{ fontSize: 10.5, color: 'var(--warning)', flexShrink: 0, marginLeft: 6 }}>lag {g.total_lag}</span>
+                  )}
+                </button>
+              ))}
+              {groups.length === 0 && groupsOpen && (
+                <div style={{ padding: '4px 12px 8px 30px', fontSize: 12, color: 'var(--text-muted)' }}>No consumer groups.</div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflow: 'auto', padding: selection ? 20 : 0 }}>
+        {!selection ? (
+          <div style={{ padding: 40, textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
+            <Layers size={28} style={{ opacity: 0.3, marginBottom: 10 }} />
+            <div>Select a topic or consumer group.</div>
+          </div>
+        ) : selection.kind === 'topic' ? (
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 14, fontWeight: 700 }}>{selection.name}</span>
+            </div>
+
+            <div style={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 6 }}>Partitions</div>
+            {loadingOffsets ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'var(--text-muted)', fontSize: 12.5, marginBottom: 16 }}>
+                <Loader2 size={13} className="spin" /> Loading offsets…
+              </div>
+            ) : (
+              <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 20 }}>
+                <thead><tr>
+                  <th style={headStyle}>Partition</th><th style={headStyle}>Low</th><th style={headStyle}>High</th><th style={headStyle}>Count</th><th style={headStyle}></th>
+                </tr></thead>
+                <tbody>
+                  {offsets.map(o => (
+                    <tr key={o.partition} style={{ cursor: 'pointer', background: partition === o.partition ? 'var(--brand-glow)' : 'none' }}
+                      onClick={() => setPartition(o.partition)}>
+                      <td style={cellStyle}>{o.partition}</td>
+                      <td style={cellStyle}>{o.low}</td>
+                      <td style={cellStyle}>{o.high}</td>
+                      <td style={cellStyle}>{o.high - o.low}</td>
+                      <td style={cellStyle}>{partition === o.partition && <span style={{ color: 'var(--brand-primary)', fontSize: 11 }}>viewing ▸</span>}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+              <div style={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', color: 'var(--text-muted)', display: 'flex', alignItems: 'center', gap: 6 }}>
+                <MessageSquare size={12} /> Recent messages — partition {partition}
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <input className="input" type="number" min={1} max={200} value={messageLimit}
+                  onChange={e => setMessageLimit(Number(e.target.value) || 20)}
+                  style={{ width: 64, fontSize: 12, padding: '4px 8px', height: 26 }} />
+                <button className="btn-icon" onClick={() => loadMessages(selection.name, partition, messageLimit)} title="Refresh" style={{ width: 26, height: 26 }}>
+                  <RefreshCw size={12} />
+                </button>
+              </div>
+            </div>
+            {loadingMessages ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'var(--text-muted)', fontSize: 12.5 }}>
+                <Loader2 size={13} className="spin" /> Loading messages…
+              </div>
+            ) : messages.length === 0 ? (
+              <div style={{ fontSize: 12.5, color: 'var(--text-muted)' }}>No messages on this partition.</div>
+            ) : (
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead><tr>
+                  <th style={headStyle}>Offset</th><th style={headStyle}>Key</th><th style={headStyle}>Value</th><th style={headStyle}>Time</th>
+                </tr></thead>
+                <tbody>
+                  {messages.map(m => (
+                    <tr key={m.offset}>
+                      <td style={cellStyle}>{m.offset}</td>
+                      <td style={{ ...cellStyle, color: 'var(--text-muted)' }}>{m.key || <em>—</em>}</td>
+                      <td style={{ ...cellStyle, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>{m.value}</td>
+                      <td style={{ ...cellStyle, color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>{fmtTime(m.timestamp)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        ) : (
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 14, fontWeight: 700 }}>{selection.id}</span>
+              {selectedGroup && <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>{selectedGroup.protocol_type}</span>}
+            </div>
+            {selectedGroup && (
+              <div style={{ fontSize: 12.5, color: selectedGroup.total_lag > 0 ? 'var(--warning)' : 'var(--success)', marginBottom: 16 }}>
+                Total lag: {selectedGroup.total_lag}
+              </div>
+            )}
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead><tr>
+                <th style={headStyle}>Topic</th><th style={headStyle}>Partition</th><th style={headStyle}>Committed</th><th style={headStyle}>High watermark</th><th style={headStyle}>Lag</th>
+              </tr></thead>
+              <tbody>
+                {(selectedGroup?.partitions ?? []).map((p, i) => (
+                  <tr key={i}>
+                    <td style={cellStyle}>{p.topic}</td>
+                    <td style={cellStyle}>{p.partition}</td>
+                    <td style={cellStyle}>{p.committed_offset}</td>
+                    <td style={cellStyle}>{p.high_watermark}</td>
+                    <td style={{ ...cellStyle, color: p.lag > 0 ? 'var(--warning)' : 'var(--text-secondary)' }}>{p.lag}</td>
+                  </tr>
+                ))}
+                {(!selectedGroup || selectedGroup.partitions.length === 0) && (
+                  <tr><td style={cellStyle} colSpan={5}>No committed offsets for this group.</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ResourceDetail.tsx
+++ b/frontend/src/pages/ResourceDetail.tsx
@@ -18,6 +18,7 @@ import { SchemaTree } from '../components/database/SchemaTree'
 import { DataGrid } from '../components/database/DataGrid'
 import { SqlConsole } from '../components/database/SqlConsole'
 import { RedisBrowser } from '../components/database/RedisBrowser'
+import { KafkaBrowser } from '../components/database/KafkaBrowser'
 
 interface ResourceDetailData {
   id: number; name: string; description?: string; tags?: string
@@ -29,7 +30,7 @@ interface UserData { id: number; username: string; email?: string; role: string 
 interface AccessEntry { id: number; resource_id: number; user_id: number; access_level: string; user?: UserData; created_at?: string }
 interface AuditEntry { id: number; resource_id: number; user_id: number; action: string; details: string; performed_by: string; created_at: string }
 interface MetricRow { id: number; timestamp: string; status: string; latency_ms: number; error?: string; metrics: string }
-type ResourceTab = 'observability' | 'overview' | 'database' | 'redis' | 'access' | 'audit'
+type ResourceTab = 'observability' | 'overview' | 'database' | 'redis' | 'kafka' | 'access' | 'audit'
 
 interface LiveProbe { status: string; latency_ms: number; error?: string; metrics: Record<string, unknown> }
 
@@ -162,6 +163,7 @@ export function ResourceDetail() {
 
   const isSqlable = ['postgres', 'postgresql', 'mysql', 'mariadb'].includes(resource?.protocol ?? '')
   const isRedis = resource?.protocol === 'redis'
+  const isKafka = resource?.protocol === 'kafka'
 
   useEffect(() => { if (id) loadPageData() }, [id])
   useEffect(() => { if (activeTab === 'audit') loadAudit() }, [auditLimit, auditSince, auditUntil, activeTab])
@@ -312,6 +314,7 @@ export function ResourceDetail() {
     { id: 'overview', label: 'Overview', icon: Database },
     ...(isSqlable ? [{ id: 'database', label: 'Database', icon: Code }] : []),
     ...(isRedis ? [{ id: 'redis', label: 'Keys', icon: KeyRound }] : []),
+    ...(isKafka ? [{ id: 'kafka', label: 'Topics', icon: Layers }] : []),
     { id: 'access', label: 'Access', icon: Lock },
     { id: 'audit', label: 'Audit Log', icon: History },
   ]
@@ -562,6 +565,13 @@ export function ResourceDetail() {
       {activeTab === 'redis' && resource && (
         <div className="card" style={{ padding: 0, height: 'calc(100vh - 280px)', minHeight: 500, overflow: 'hidden' }}>
           <RedisBrowser resourceId={resource.id} canEdit={can('manage-resources')} />
+        </div>
+      )}
+
+      {/* ── Kafka topics ── */}
+      {activeTab === 'kafka' && resource && (
+        <div className="card" style={{ padding: 0, height: 'calc(100vh - 280px)', minHeight: 500, overflow: 'hidden' }}>
+          <KafkaBrowser resourceId={resource.id} />
         </div>
       )}
 

--- a/frontend/src/types/kafka.ts
+++ b/frontend/src/types/kafka.ts
@@ -1,0 +1,52 @@
+// ── Kafka topic browser (read-only) ──
+
+export interface KafkaTopicInfo {
+  name: string
+  partitions: number
+}
+
+export interface KafkaTopicsResponse {
+  topics: KafkaTopicInfo[]
+}
+
+export interface KafkaPartitionOffset {
+  partition: number
+  low: number
+  high: number
+}
+
+export interface KafkaOffsetsResponse {
+  topic: string
+  partitions: KafkaPartitionOffset[]
+}
+
+export interface KafkaMessage {
+  partition: number
+  offset: number
+  key: string
+  value: string
+  timestamp: string
+}
+
+export interface KafkaMessagesResponse {
+  messages: KafkaMessage[]
+}
+
+export interface KafkaGroupPartition {
+  topic: string
+  partition: number
+  committed_offset: number
+  high_watermark: number
+  lag: number
+}
+
+export interface KafkaGroupInfo {
+  group_id: string
+  protocol_type: string
+  total_lag: number
+  partitions: KafkaGroupPartition[]
+}
+
+export interface KafkaGroupsResponse {
+  groups: KafkaGroupInfo[]
+}


### PR DESCRIPTION
## Summary

Phase 3 (final phase) of the DataGrip-style Resources UI project — Phase 1 (Postgres/MySQL Database tab, #139) and Phase 2 (Redis Keys tab, #140) are already merged. Adds a read-only "Topics" tab for Kafka resources.

**Backend** (`backend/internal/resources/kafka.go`, `backend/internal/handlers/resource_kafka.go`):
- `KafkaDialer`/`KafkaClient` — gateway-aware connections reusing the shared `dialResourceCtx` choke point; `probeKafka` refactored to use `KafkaDialer` instead of building its own dialer inline
- `GET /resources/:id/kafka/topics` — topic list with partition counts (excludes internal `__`-prefixed topics)
- `GET /resources/:id/kafka/topics/:topic/offsets` — per-partition low/high watermarks
- `GET /resources/:id/kafka/topics/:topic/messages` — bounded recent-message tail on one partition; audit-logged as `browse_kafka_messages` (same precedent as `browse_table` for endpoints that expose real message/row content)
- `GET /resources/:id/kafka/groups` — consumer groups with per-topic-partition committed offset / high watermark / lag

No write endpoints — topic browsing is inherently read-only, unlike the SQL/Redis tabs, so there's no `requireWriteAccess` gate here.

**Frontend** (`frontend/src/components/database/KafkaBrowser.tsx`, `frontend/src/types/kafka.ts`, `ResourceDetail.tsx`):
- New "Topics" tab shown only for `protocol === 'kafka'`
- Sidebar with two collapsible sections (topics, consumer groups)
- Detail pane: a topic shows its partition offset table (click a row to switch partitions) plus a recent-message tail; a group shows its total lag and a per-topic-partition breakdown

## Test plan

Live-verified end-to-end against a real single-node Kafka container (2 topics, 3 partitions total, one consumer group with real lag), cross-checked against `kafka-topics.sh`/`kafka-consumer-groups.sh` output:
- [x] Topic list shows correct names and partition counts
- [x] Partition offsets (low/high) match the broker's actual watermarks
- [x] Message tail on two different partitions shows correct key/value/timestamp, respects the limit
- [x] Consumer group lag (committed offset vs. high watermark) matches native CLI output exactly
- [x] `go build`/`go vet` clean (scoped to `./cmd/server/... ./internal/...`)
- [x] `npx tsc -b` clean
- [x] Test resource and test Kafka container removed after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf