### PR TITLE
fix(resources): never let a malformed schema/redis response crash the tab

### DIFF
--- a/frontend/src/components/database/DataGrid.tsx
+++ b/frontend/src/components/database/DataGrid.tsx
@@ -79,6 +79,9 @@ export function DataGrid({ resourceId, schema, table, canEdit }: DataGridProps) 
         api.get<ColumnInfo[]>(`/api/resources/${resourceId}/schema/${schema}/${table}/columns`),
         api.get<TableRowsResponse>(`/api/resources/${resourceId}/schema/${schema}/${table}/rows`, { params: { limit: PAGE_SIZE, offset } }),
       ])
+      if (!Array.isArray(colsRes.data) || !Array.isArray(rowsRes.data.rows)) {
+        throw new Error('Unexpected response from server')
+      }
       setColumns(colsRes.data)
       setData(rowsRes.data)
     } catch (err: unknown) {

--- a/frontend/src/components/database/RedisBrowser.tsx
+++ b/frontend/src/components/database/RedisBrowser.tsx
@@ -54,7 +54,8 @@ export function RedisBrowser({ resourceId, canEdit }: RedisBrowserProps) {
       const res = await api.get<RedisKeysResponse>(`/api/resources/${resourceId}/redis/keys`, {
         params: { pattern, cursor: reset ? '0' : cursor, count: 200 },
       })
-      setKeys(prev => reset ? res.data.keys : [...prev, ...res.data.keys])
+      const keys = res.data.keys ?? []
+      setKeys(prev => reset ? keys : [...prev, ...keys])
       setCursor(res.data.cursor)
     } catch (err: unknown) {
       toast.error('Scan failed', errMessage(err))

--- a/frontend/src/components/database/SchemaTree.tsx
+++ b/frontend/src/components/database/SchemaTree.tsx
@@ -26,6 +26,7 @@ export function SchemaTree({ resourceId, selected, onSelect }: SchemaTreeProps) 
     setError(null)
     try {
       const res = await api.get<SchemaGroup[]>(`/api/resources/${resourceId}/schema`)
+      if (!Array.isArray(res.data)) throw new Error('Unexpected response from server')
       setGroups(res.data)
       // First schema starts expanded so the tree isn't empty-looking on load.
       if (res.data.length > 0) setExpanded(prev => Object.keys(prev).length ? prev : { [res.data[0].schema]: true })


### PR DESCRIPTION
## Summary

A user hit a hard crash (`ErrorBoundary: "groups.map is not a function"`) opening the Database tab on a resource against an older/mismatched deployment, where the schema endpoint's response shape apparently didn't match what the current frontend expects.

I reproduced the underlying trigger condition — a resource that fails to connect (bad Postgres credentials) — against current `main`, and it does **not** crash: `SchemaTree` already renders the failure inline correctly. So this isn't a regression in current code, but the component was still trusting the API response's shape blindly on the success path, meaning any future version-skew or malformed response would crash the whole tab instead of using the error UI that already exists for exactly this purpose.

- `SchemaTree.tsx`, `DataGrid.tsx`: throw before `setState` if the response isn't shaped as expected, routing it into the existing `error` state instead of letting a later `.map()` throw during render
- `RedisBrowser.tsx`: same class of gap on the key-list response, fixed with a `?? []` fallback

## Test plan

- [x] Reproduced the original failure condition (a Postgres resource with bad credentials) against current code, both before and after this change — inline error message renders correctly in both cases, no regression
- [x] `npx tsc -b` clean
- [x] Test resource removed after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf