### PR TITLE
chore: bump version to 1.6.15

### DIFF
--- a/backend/cmd/desktop/wails.json
+++ b/backend/cmd/desktop/wails.json
@@ -10,7 +10,7 @@
   "info": {
     "companyName": "InfraEye",
     "productName": "InfraEye",
-    "productVersion": "1.6.14",
+    "productVersion": "1.6.15",
     "copyright": "Copyright © 2026 InfraEye",
     "comments": "Agentless observability platform"
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.14",
+      "version": "1.6.15",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.14",
+  "version": "1.6.15",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Version bump covering everything merged since 1.6.14 (#133):
- #134 fix: audit/DAST findings not persisting across tab switches
- #135 fix: nil-slice crash on cluster/kernel/hardening/resource scans with zero results
- #136 redesign: Alert Rules color scheme (color now meaningful only for critical severity)
- #137 fix: dark-mode icon-button visibility (~15 spots)
- #138 fix: duplicate/stacked toast notifications
- #139 feat: DataGrip-style Database tab (Postgres/MySQL schema browser, data grid, SQL console) — Phase 1
- #140 feat: Redis Keys tab — Phase 2
- #141 feat: Kafka Topics tab — Phase 3
- #142 fix: defensive guard against malformed schema/redis API responses crashing the tab

`wails.json`'s `productVersion` stamped via `make desktop-stamp-version` so it stays in sync with `frontend/package.json`, the single source of truth.

## Test plan

- [x] Every listed change was already individually verified live and merged through its own PR
- [x] `desktop-stamp-version` output confirms `wails.json` now reads 1.6.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YtHTWmAREF7p7DgeQ7Kf