### PR TITLE
chore: bump version to 1.6.16

### DIFF
--- a/backend/cmd/desktop/wails.json
+++ b/backend/cmd/desktop/wails.json
@@ -10,7 +10,7 @@
   "info": {
     "companyName": "InfraEye",
     "productName": "InfraEye",
-    "productVersion": "1.6.15",
+    "productVersion": "1.6.16",
     "copyright": "Copyright © 2026 InfraEye",
     "comments": "Agentless observability platform"
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.6.15",
+  "version": "1.6.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.6.15",
+      "version": "1.6.16",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.15",
+  "version": "1.6.16",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Covers #144 (DAST scanner ZAP report-file parsing fix — blank URL column and risk always collapsing to "info" on Docker-driven scans).

wails.json's productVersion stamped via `make desktop-stamp-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014toFFLeDjKypiCpheBBP9u